### PR TITLE
fix: room occupants of remote nodes kicked out unexpectedly in cluster env

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -292,7 +292,6 @@ public class MUCRoomController {
         
         // Fire RoomUpdateEvent if cluster is started
         if (ClusterManager.isClusteringStarted()) {
-          CacheFactory.doClusterTask(new RoomAvailableEvent((LocalMUCRoom) room));
           CacheFactory.doClusterTask(new RoomUpdatedEvent((LocalMUCRoom) room));
         }
 


### PR DESCRIPTION
Hello, I’m using Openfire 4.2.3 with REST API plugin 1.3.9 and two nodes hazelcast cluster (plugin 2.4.2).
I found unexpected behavior of `PUT /plugins/restapi/v1/chatrooms/{roomName}` API. When I send the HTTP request, one cluster node that received the HTTP request has room occuoants without change but the other node has no occupants unexpectedly.
See details: https://discourse.igniterealtime.org/t/rest-api-and-multi-node-hazelcast-cluster-all-room-members-kicked-out-unexpectedly/85060

---
My commit info:

I removed `CacheFactory.doClusterTask(new RoomAvailableEvent((LocalMUCRoom) room)) ` with following reason.

- `MUCRoomController` is not responsible for room creation and `RoomAvailableEvent` is called in `mucService.getChatRoom` method.
- `RoomAvailableEvent` calls `mucService.chatRoomAdded(room)` event in its `run()` method, however `room` of `RoomAvailableEvent` does not have occupants info because `room.writeExternal(out)` does not write occupants info.
https://github.com/igniterealtime/Openfire/blob/master/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/RoomAvailableEvent.java#L50-L58
https://github.com/igniterealtime/Openfire/blob/master/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java#L2720-L2757
Therefore, after `RoomAvailableEvent.readExternal()` and `RoomAvailableEvent.run()`, the room is loaded without occupants info.

Another option is to separate the Create and Update methods (now, `updateChatRoom` calls `createRoom` method).

Thank you for reading and please review.