### PR TITLE
Add User Address when getting room occupants.

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -14,9 +14,9 @@ import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.group.ConcurrentGroupList;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.muc.*;
-import org.jivesoftware.openfire.muc.cluster.RoomAvailableEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomUpdatedEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomRemovedEvent;
+import org.jivesoftware.openfire.muc.cluster.RoomAvailableEvent;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
 import org.jivesoftware.openfire.plugin.rest.entity.*;
@@ -351,6 +351,7 @@ public class MUCRoomController {
         for (MUCRole role : serverOccupants) {
             OccupantEntity occupantEntity = new OccupantEntity();
             occupantEntity.setJid(role.getRoleAddress().toFullJID());
+            occupantEntity.setUserAddress(role.getUserAddress().toFullJID());
             occupantEntity.setRole(role.getRole().name());
             occupantEntity.setAffiliation(role.getAffiliation().name());
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/OccupantEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/OccupantEntity.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class OccupantEntity {
 
     private String jid;
+    private String userAddress;
     private String role;
     private String affiliation;
 
@@ -40,4 +41,11 @@ public class OccupantEntity {
         this.affiliation = affiliation;
     }
 
+    public String getUserAddress() {
+        return userAddress;
+    }
+
+    public void setUserAddress(String userAddress) {
+        this.userAddress = userAddress;
+    }
 }


### PR DESCRIPTION
Had a situation where we needed the User Address JID instead of the MUC JID, creating a PR because others may find this a useful addition.