### PR TITLE
Add an API to return load on each server i.e. number of local sessions.

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SessionController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SessionController.java
@@ -66,6 +66,18 @@ public class SessionController {
     }
     
     /**
+     * Gets the number of all sessions.
+     *
+     * @return the number of all sessions
+     * @throws ServiceException the service exception
+     */
+    public SessionEntities getAllSessionsLoad() throws ServiceException {
+        Collection<ClientSession> clientSessions = SessionManager.getInstance().getSessions();
+        SessionEntities sessionEntities = convertToSessionEntitiesLoad(clientSessions);
+        return sessionEntities;
+    }
+
+    /**
      * Removes the user sessions.
      *
      * @param username the username
@@ -77,6 +89,34 @@ public class SessionController {
             session.deliverRawText(error.toXML());
             session.close();
         }
+    }
+
+    /**
+     * Convert to session entities.
+     *
+     * @param clientSessions the client sessions
+     * @return the session entities
+     * @throws ServiceException the service exception
+     */
+    private SessionEntities convertToSessionEntitiesLoad(Collection<ClientSession> clientSessions) throws ServiceException {
+        int load = 0;
+
+        List<SessionEntity> sessions = new ArrayList<SessionEntity>();
+        SessionEntities sessionEntities = new SessionEntities(sessions);
+
+        for (ClientSession clientSession : clientSessions) {
+            if (clientSession instanceof LocalClientSession) {
+              ++load;
+            }
+        }
+
+        SessionEntity session = new SessionEntity();
+
+        session.setLoad(load);
+
+        sessions.add(session);
+
+        return sessionEntities;
     }
 
     /**
@@ -144,7 +184,11 @@ public class SessionController {
                 }
                 session.setPriority(clientSession.getPresence().getPriority());
             }
-            
+
+            // Load is set to the real local load of each server when specific
+            // REST query is received.
+            session.setLoad(0);
+
             try {
                 session.setHostAddress(clientSession.getHostAddress());
                 session.setHostName(clientSession.getHostName());

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/SessionEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/SessionEntity.java
@@ -7,7 +7,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name = "session")
-@XmlType(propOrder = { "sessionId", "username", "resource", "node", "sessionStatus", "presenceStatus", "presenceMessage", "priority",
+@XmlType(propOrder = { "sessionId", "username", "resource", "node", "sessionStatus", "presenceStatus", "presenceMessage", "priority", "load",
         "hostAddress", "hostName", "creationDate", "lastActionDate", "secure" })
 public class SessionEntity {
 
@@ -19,6 +19,7 @@ public class SessionEntity {
     private String presenceStatus;
     private String presenceMessage;
     private int priority;
+    private int load;
     private String hostAddress;
     private String hostName;
 
@@ -90,6 +91,15 @@ public class SessionEntity {
 
     public void setPresenceMessage(String presenceMessage) {
         this.presenceMessage = presenceMessage;
+    }
+
+    @XmlElement
+    public int getLoad() {
+      return load;
+    }
+
+    public void setLoad(int load) {
+      this.load = load;
     }
 
     @XmlElement

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/SessionService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/SessionService.java
@@ -30,6 +30,13 @@ public class SessionService {
     }
     
     @GET
+    @Path("/load")
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public SessionEntities getAllSessionsLoad() throws ServiceException {
+        return sessionController.getAllSessionsLoad();
+    }
+
+    @GET
     @Path("/{username}")
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     public SessionEntities getUserSessions(@PathParam("username") String username) throws ServiceException {


### PR DESCRIPTION
The main intention of this patch was to make it possible to get the local load of each instance of Openfire in a clustered environment so the load balancer would know where to route the traffic.

There might be better solutions but this is our way to solve the problem so far. Hope this patch is useful and will be accepted.
