### PR TITLE
Allow to use user group with roles on create/update chat room.

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -513,11 +513,13 @@ public class MUCRoomController {
     private void setRoles(MUCRoom room, MUCRoomEntity mucRoomEntity) throws ForbiddenException, NotAllowedException,
             ConflictException {
         List<JID> roles = new ArrayList<JID>();
-        Collection<JID> owners = new ArrayList<JID>();
         Collection<JID> existingOwners = new ArrayList<JID>();
+        List<JID> mucRoomEntityOwners = new ArrayList<JID>();
 
-        List<JID> mucRoomEntityOwners = MUCRoomUtils.convertStringsToJIDs(mucRoomEntity.getOwners());
-        owners.addAll(room.getOwners());
+        for (String ownerJid : mucRoomEntity.getOwners()) {
+            mucRoomEntityOwners.add(UserUtils.checkAndGetJID(ownerJid));
+        }
+        Collection<JID> owners = new ArrayList<JID>(room.getOwners());
 
         // Find same owners
         for (JID jid : owners) {
@@ -528,7 +530,6 @@ public class MUCRoomController {
 
         // Don't delete the same owners
         owners.removeAll(existingOwners);
-        room.addOwners(MUCRoomUtils.convertStringsToJIDs(mucRoomEntity.getOwners()), room.getRole());
 
         // Collect all roles to reset
         roles.addAll(owners);
@@ -540,18 +541,22 @@ public class MUCRoomController {
             room.addNone(jid, room.getRole());
         }
 
-        room.addOwners(MUCRoomUtils.convertStringsToJIDs(mucRoomEntity.getOwners()), room.getRole());
+        for (String ownerJid : mucRoomEntity.getOwners()) {
+            room.addOwner(UserUtils.checkAndGetJID(ownerJid), room.getRole());
+        }
         if (mucRoomEntity.getAdmins() != null) {
-            room.addAdmins(MUCRoomUtils.convertStringsToJIDs(mucRoomEntity.getAdmins()), room.getRole());
+            for (String adminJid : mucRoomEntity.getAdmins()) {
+                room.addAdmin(UserUtils.checkAndGetJID(adminJid), room.getRole());
+            }
         }
         if (mucRoomEntity.getMembers() != null) {
             for (String memberJid : mucRoomEntity.getMembers()) {
-                room.addMember(new JID(memberJid), null, room.getRole());
+                room.addMember(UserUtils.checkAndGetJID(memberJid), null, room.getRole());
             }
         }
         if (mucRoomEntity.getOutcasts() != null) {
             for (String outcastJid : mucRoomEntity.getOutcasts()) {
-                room.addOutcast(new JID(outcastJid), null, room.getRole());
+                room.addOutcast(UserUtils.checkAndGetJID(outcastJid), null, room.getRole());
             }
         }
     }


### PR DESCRIPTION
Hello!
We can use [Add group with role to chat room](https://www.igniterealtime.org/projects/openfire/plugins/1.3.8/restAPI/readme.html#add-group-with-role-to-chat-room) endpoint to add a new group with role to a room. Suppose, it should be also possible to do when [creating](https://www.igniterealtime.org/projects/openfire/plugins/1.3.8/restAPI/readme.html#create-a-chat-room) / [updating](https://www.igniterealtime.org/projects/openfire/plugins/1.3.8/restAPI/readme.html#update-a-chat-room) a chat room.
E.g.:
>
    <chatRoom>
        <roomName>global</roomName>
        ...
        <members>
            <member>user1@localhost</member>
            <member>user2</member>
            <member>group1</member>
        </members>
        ...
    </chatRoom>
Please review and let me know what do you think.