### PR TITLE
Openfire 4.6 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.6.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -669,7 +669,7 @@ public class MUCRoomController {
               // Send a presence to other room members
               List<Presence> addNonePresence = room.addNone(userJid, room.getRole());
               for (Presence presence : addNonePresence) {
-                room.send(presence);
+                room.send(presence, room.getRole());
               }
         } catch (ForbiddenException e) {
             throw new ServiceException("Could not delete affiliation", jid, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN, e);


### PR DESCRIPTION
Openfire released a breaking change in version 4.6 by changing the signature of the `MUCRoom.send` function. 
Therefore this plugin does not work properly with Openfire >= 4.6.0.

This pull request attempts to restore compatibility with the current Openfire versions.
~~I don't know if you can release a new version for that, because this will of course break the plugin for all the older Openfire versions, but I thought I'd share my 4.6-compatible fork anyway.~~


