### PR TITLE
fixes #56: Bump Openfire dependency to 4.6.1

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,12 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.6.0</b> (to be determined))</p>
+<ul>
+    <li>This plugin now requires Openfire 4.6.1 or later</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/56'>#56</a>] - Fix for incompatibility with Openfire v4.6.1 and later</li>
+</ul>
+
 <p><b>1.5.0</b> March 5th, 2021</p>
 <ul>
     <li>Openfire 4.6 Compatibility (MUCRoom.send signature)</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
     <date>02/24/2020</date>
-    <minServerVersion>4.1.1</minServerVersion>
+    <minServerVersion>4.6.1</minServerVersion>
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0-SNAPSHOT</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
@@ -263,9 +264,9 @@ public class MUCRoomController {
 
         // Set broadcast presence roles
         if (mucRoomEntity.getBroadcastPresenceRoles() != null) {
-            room.setRolesToBroadcastPresence(mucRoomEntity.getBroadcastPresenceRoles());
+            room.setRolesToBroadcastPresence(MUCRoomUtils.convertStringsToRoles(mucRoomEntity.getBroadcastPresenceRoles()));
         } else {
-            room.setRolesToBroadcastPresence(new ArrayList<String>());
+            room.setRolesToBroadcastPresence(new ArrayList<>());
         }
         // Set all roles
         if (!equalToAffiliations(room, mucRoomEntity)) {
@@ -511,7 +512,7 @@ public class MUCRoomController {
         mucRoomEntity.setMemberGroups(MUCRoomUtils.convertGroupsToStringList(members.getGroups()));
         mucRoomEntity.setOutcastGroups(MUCRoomUtils.convertGroupsToStringList(outcasts.getGroups()));
 
-        mucRoomEntity.setBroadcastPresenceRoles(room.getRolesToBroadcastPresence());
+        mucRoomEntity.setBroadcastPresenceRoles(MUCRoomUtils.convertRolesToStringList(room.getRolesToBroadcastPresence()));
 
         mucRoomEntity.setCreationDate(room.getCreationDate());
         mucRoomEntity.setModificationDate(room.getModificationDate());

--- a/src/java/org/jivesoftware/openfire/plugin/rest/utils/MUCRoomUtils.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/utils/MUCRoomUtils.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.muc.MUCRole;
@@ -69,6 +70,32 @@ public class MUCRoomUtils {
             result.add(new JID(jidString));
         }
         return result;
+    }
+
+    /**
+     * Convert MUCRole.role instances to string list.
+     *
+     * @param roles
+     *            the roles
+     * @return the array list<string>
+     */
+    public static List<String> convertRolesToStringList(Collection<MUCRole.Role> roles) {
+        return roles.stream()
+            .map(MUCRole.Role::toString)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Convert string instances to a MUCRole.role list.
+     *
+     * @param roles
+     *            the roles
+     * @return the array list<MUCRole.role>
+     */
+    public static List<MUCRole.Role> convertStringsToRoles(Collection<String> roles) {
+        return roles.stream()
+            .map(MUCRole.Role::valueOf)
+            .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Openfire 4.6.1 introduced an API change that made older versions of the restAPI plugin incompatible.

This commit increased the dependency of Openfire to version 4.6.1, which will resolve exceptions that report ` org.jivesoftware.openfire.muc.MUCRole$Role cannot be cast to java.lang.String`