### PR TITLE
Fix #52 by setting group roster sharing to false by default

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ REST API Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/1'>#1</a>] - Migrate to Swagger.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/25'>#25</a>] - Java 11 Jaxb issue</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/39'>#39</a>] - Requests fail when using XML as accept type on Openfire servers running java 11</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/52'>#52</a>] - Create groups as private by default, and add config to allow roster sharing if desired</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/67'>#67</a>] - Updated Jersey dependency to 2.35.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/68'>#68</a>] - Fix for incompatibility with Openfire v4.7.0-beta and later</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/77'>#77</a>] - Add dependency checking</li>

--- a/readme.html
+++ b/readme.html
@@ -1846,6 +1846,7 @@
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>
 	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>GroupName<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
 	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Some description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
+	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>shared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>shared</span><span class="token punctuation">&gt;</span></span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h2 id="delete-a-group">Delete a group</h2>
@@ -1920,6 +1921,7 @@
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>
 	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>groupNameToUpdate<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
 	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>New description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
+	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>shared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>shared</span><span class="token punctuation">&gt;</span></span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h1 id="session-related-rest-endpoints">Session related REST Endpoints</h1>

--- a/readme.md
+++ b/readme.md
@@ -1303,6 +1303,7 @@ Endpoint to create a new group
 <group>
 	<name>GroupName</name>
 	<description>Some description</description>
+	<isshared>false</isshared>
 </group>
 ```
 
@@ -1353,6 +1354,7 @@ Endpoint to update / overwrite a group
 <group>
 	<name>groupNameToUpdate</name>
 	<description>New description</description>
+    <isshared>false</isshared>
 </group>
 ```
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/GroupController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/GroupController.java
@@ -70,6 +70,7 @@ public class GroupController {
         GroupEntity groupEntity = new GroupEntity(group.getName(), group.getDescription());
         groupEntity.setAdmins(MUCRoomUtils.convertJIDsToStringList(group.getAdmins()));
         groupEntity.setMembers(MUCRoomUtils.convertJIDsToStringList(group.getMembers()));
+        groupEntity.setShared(group.getProperties().get("sharedRoster.showInRoster")=="onlyGroup");
 
         return groupEntity;
     }
@@ -90,7 +91,11 @@ public class GroupController {
                 group = GroupManager.getInstance().createGroup(groupEntity.getName());
                 group.setDescription(groupEntity.getDescription());
 
-                group.getProperties().put("sharedRoster.showInRoster", "onlyGroup");
+                Boolean shared = groupEntity.getShared();
+                if(shared == null){shared = false;}
+                final String showInRoster = shared ? "onlyGroup" : "nobody";
+                group.getProperties().put("sharedRoster.showInRoster", showInRoster);
+
                 group.getProperties().put("sharedRoster.displayName", groupEntity.getName());
                 group.getProperties().put("sharedRoster.groupList", "");
             } catch (GroupAlreadyExistsException e) {
@@ -119,6 +124,11 @@ public class GroupController {
                 try {
                     group = GroupManager.getInstance().getGroup(groupName);
                     group.setDescription(groupEntity.getDescription());
+                    Boolean shared = groupEntity.getShared();
+                    if(shared != null) {
+                        final String showInRoster = shared ? "onlyGroup" : "nobody";
+                        group.getProperties().put("sharedRoster.showInRoster", showInRoster);
+                    }
                 } catch (GroupNotFoundException e) {
                     throw new ServiceException("Could not find group", groupName, ExceptionType.GROUP_NOT_FOUND,
                             Response.Status.NOT_FOUND, e);

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/GroupController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/GroupController.java
@@ -91,9 +91,7 @@ public class GroupController {
                 group = GroupManager.getInstance().createGroup(groupEntity.getName());
                 group.setDescription(groupEntity.getDescription());
 
-                Boolean shared = groupEntity.getShared();
-                if(shared == null){shared = false;}
-                final String showInRoster = shared ? "onlyGroup" : "nobody";
+                final String showInRoster = groupEntity.getShared() ? "onlyGroup" : "nobody";
                 group.getProperties().put("sharedRoster.showInRoster", showInRoster);
 
                 group.getProperties().put("sharedRoster.displayName", groupEntity.getName());
@@ -124,11 +122,8 @@ public class GroupController {
                 try {
                     group = GroupManager.getInstance().getGroup(groupName);
                     group.setDescription(groupEntity.getDescription());
-                    Boolean shared = groupEntity.getShared();
-                    if(shared != null) {
-                        final String showInRoster = shared ? "onlyGroup" : "nobody";
-                        group.getProperties().put("sharedRoster.showInRoster", showInRoster);
-                    }
+                    final String showInRoster = groupEntity.getShared() ? "onlyGroup" : "nobody";
+                    group.getProperties().put("sharedRoster.showInRoster", showInRoster);
                 } catch (GroupNotFoundException e) {
                     throw new ServiceException("Could not find group", groupName, ExceptionType.GROUP_NOT_FOUND,
                             Response.Status.NOT_FOUND, e);

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
@@ -106,7 +106,7 @@ public class UserServiceLegacyController {
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
                     group = GroupManager.getInstance().createGroup(groupName);
-                    group.getProperties().put("sharedRoster.showInRoster", "onlyGroup");
+                    group.getProperties().put("sharedRoster.showInRoster", "nobody");
                     group.getProperties().put("sharedRoster.displayName", groupName);
                     group.getProperties().put("sharedRoster.groupList", "");
                 }
@@ -188,7 +188,7 @@ public class UserServiceLegacyController {
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
                     group = GroupManager.getInstance().createGroup(groupName);
-                    group.getProperties().put("sharedRoster.showInRoster", "onlyGroup");
+                    group.getProperties().put("sharedRoster.showInRoster", "nobody");
                     group.getProperties().put("sharedRoster.displayName", groupName);
                     group.getProperties().put("sharedRoster.groupList", "");
                 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/GroupEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/GroupEntity.java
@@ -3,6 +3,7 @@ package org.jivesoftware.openfire.plugin.rest.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
@@ -13,7 +14,7 @@ import javax.xml.bind.annotation.XmlType;
  * The Class GroupEntity.
  */
 @XmlRootElement(name = "group")
-@XmlType(propOrder = { "name", "description", "admins", "members" })
+@XmlType(propOrder = { "name", "description", "admins", "members", "shared" })
 public class GroupEntity {
 
     /** The name. */
@@ -27,6 +28,9 @@ public class GroupEntity {
 
     /** The members. */
     private List<String> members;
+
+    /** The visibility */
+    private Boolean shared;
 
     /**
      * Instantiates a new group entity.
@@ -128,5 +132,21 @@ public class GroupEntity {
     public void setMembers(List<String> members) {
         this.members = members;
     }
+
+
+    /**
+     * Gets whether this is a shared group
+     *
+     * @return whether it's a shared group
+     */
+    @XmlElement(name = "shared")
+    public Boolean getShared(){ return shared; }
+
+    /**
+     * Sets whether this is a shared group
+     *
+     * @param shared whether this is a shared group
+     */
+    public void setShared(Boolean shared) { this.shared = shared; }
 
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/GroupEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/GroupEntity.java
@@ -1,6 +1,8 @@
 package org.jivesoftware.openfire.plugin.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 import java.util.Optional;
@@ -57,6 +59,7 @@ public class GroupEntity {
      * @return the name
      */
     @XmlElement
+    @Schema(description = "Name of the group", example = "UserGroup1")
     public String getName() {
         return name;
     }
@@ -77,6 +80,7 @@ public class GroupEntity {
      * @return the description
      */
     @XmlElement
+    @Schema(description = "Description of the group", example = "My group of users")
     public String getDescription() {
         return description;
     }
@@ -99,6 +103,7 @@ public class GroupEntity {
     @XmlElementWrapper(name = "admins")
     @XmlElement(name = "admin")
     @JsonProperty(value = "admins")
+    @ArraySchema(schema = @Schema(example = "jane.smith"), arraySchema = @Schema(description = "List of admins of the group"))
     public List<String> getAdmins() {
         return admins;
     }
@@ -111,6 +116,7 @@ public class GroupEntity {
     @XmlElementWrapper(name = "members")
     @XmlElement(name = "member")
     @JsonProperty(value = "members")
+    @ArraySchema(schema = @Schema(example = "john.jones"), arraySchema = @Schema(description = "List of members of the group"))
     public List<String> getMembers() {
         return members;
     }
@@ -140,6 +146,7 @@ public class GroupEntity {
      * @return whether it's a shared group
      */
     @XmlElement(name = "shared")
+    @Schema(description = "Whether the group should automatically appear in the rosters of the users", example = "false")
     public Boolean getShared(){ return shared; }
 
     /**

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/GroupEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/GroupEntity.java
@@ -29,8 +29,8 @@ public class GroupEntity {
     /** The members. */
     private List<String> members;
 
-    /** The visibility */
-    private Boolean shared;
+    /** The visibility, false unless set */
+    private Boolean shared = false;
 
     /**
      * Instantiates a new group entity.


### PR DESCRIPTION
Roster sharing is an optional parameter of creating/updating a group, but when not provided is assumed to be false.

Could be a breaking change for some users.