### PR TITLE
Add dependency check report

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ REST API Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/25'>#25</a>] - Java 11 Jaxb issue</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/39'>#39</a>] - Requests fail when using XML as accept type on Openfire servers running java 11</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/68'>#68</a>] - Fix for incompatibility with Openfire v4.7.0-beta and later</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/77'>#77</a>] - Add dependency checking</li>
 </ul>
 
 <p><b>1.6.0</b> June 18, 2021</p>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,32 @@
 		</dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>deps</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>6.5.0</version>
+                        <configuration>
+                            <skipProvidedScope>true</skipProvidedScope>
+                            <skipRuntimeScope>true</skipRuntimeScope>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <repositories>
         <!-- Where we obtain dependencies. -->
         <repository>


### PR DESCRIPTION
`mvn verify -P deps` will create a report in the target directory called `dependency-check-report.html`, reporting on any dependencies, direct or down the chain, with known CVEs.

Fixes #77 