### PR TITLE
fixes #79: Ensure consistent JSON representation

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -54,6 +54,7 @@ REST API Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/67'>#67</a>] - Updated Jersey dependency to 2.35.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/68'>#68</a>] - Fix for incompatibility with Openfire v4.7.0-beta and later</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/77'>#77</a>] - Add dependency checking</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/79'>#79</a>] - Ensure consistent JSON representation</li>
 </ul>
 
 <p><b>1.6.0</b> June 18, 2021</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>01/07/2022</date>
+    <date>01/18/2022</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/src/java/org/jivesoftware/openfire/plugin/rest/CustomJacksonMapperProvider.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/CustomJacksonMapperProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Replaces the default ObjectMapper behavior as provided by Jackson.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+@Provider
+public class CustomJacksonMapperProvider implements ContextResolver<ObjectMapper> {
+
+    final ObjectMapper mapper;
+
+    public CustomJacksonMapperProvider() {
+        mapper = new ObjectMapper();
+
+        // Configure Jackson to use JAXB annotations as the primary, and  Jackson annotations as the secondary source.
+        mapper.registerModule(new JaxbAnnotationModule());
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return mapper;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
@@ -3,6 +3,7 @@ package org.jivesoftware.openfire.plugin.rest.service;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.jivesoftware.openfire.plugin.rest.AuthFilter;
 import org.jivesoftware.openfire.plugin.rest.CORSFilter;
+import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.util.JiveGlobals;
 
@@ -102,6 +103,9 @@ public class JerseyWrapper extends ResourceConfig {
 
         // Exception mapper
         register(RESTExceptionMapper.class);
+
+        // Jackson's Object Mapper
+        register(CustomJacksonMapperProvider.class);
 
         // Documentation (Swagger)
         register( new CustomOpenApiResource() );


### PR DESCRIPTION
Jackson's objectmapper is now configured to prefer the JAXB annotations for serialization.