### PR TITLE
Add tests to check for backwards compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,29 @@
             <artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
             <version>2.1.11</version>
         </dependency>
+
+        <!-- Testing scope dependencies -->
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>2.27</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -18,7 +18,6 @@ package org.jivesoftware.openfire.plugin.rest.controller;
 
 import org.dom4j.Element;
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.group.ConcurrentGroupList;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.muc.*;
@@ -29,6 +28,7 @@ import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.plugin.rest.utils.MUCRoomUtils;
 import org.jivesoftware.openfire.plugin.rest.utils.UserUtils;
 import org.jivesoftware.util.AlreadyExistsException;
+import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -46,7 +46,7 @@ public class MUCRoomController {
     private static Logger LOG = LoggerFactory.getLogger(MUCRoomController.class);
 
     /** The Constant INSTANCE. */
-    public static final MUCRoomController INSTANCE = new MUCRoomController();
+    private static MUCRoomController INSTANCE = null;
 
     /**
      * Gets the single instance of MUCRoomController.
@@ -54,14 +54,25 @@ public class MUCRoomController {
      * @return single instance of MUCRoomController
      */
     public static MUCRoomController getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new MUCRoomController();
+        }
         return INSTANCE;
     }
-    private static final PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
-    private static final RESTServicePlugin plugin = (RESTServicePlugin) pluginManager.getPlugin("restapi");
+
+    /**
+     * @param instance the mock/stub/spy controller to use.
+     * @deprecated - for test use only
+     */
+    @Deprecated
+    public static void setInstance(final MUCRoomController instance) {
+        MUCRoomController.INSTANCE = instance;
+    }
 
     public static void log(String logMessage) {
-        if (plugin.isServiceLoggingEnabled())
+        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
             LOG.info(logMessage);
+        }
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceController.java
@@ -16,29 +16,16 @@
 
 package org.jivesoftware.openfire.plugin.rest.controller;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import javax.ws.rs.core.Response;
-
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.SharedGroupException;
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupManager;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
 import org.jivesoftware.openfire.lockout.LockOutManager;
 import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
 import org.jivesoftware.openfire.plugin.rest.dao.PropertyDAO;
-import org.jivesoftware.openfire.plugin.rest.entity.GroupEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.RosterEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.RosterItemEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.UserEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.UserEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.UserGroupsEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.UserProperty;
+import org.jivesoftware.openfire.plugin.rest.entity.*;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.plugin.rest.utils.UserUtils;
@@ -50,11 +37,16 @@ import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.JiveGlobals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.StreamError;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * The Class UserServiceController.
@@ -63,7 +55,7 @@ public class UserServiceController {
     private static Logger LOG = LoggerFactory.getLogger(UserServiceController.class);
 
     /** The Constant INSTANCE. */
-    public static final UserServiceController INSTANCE = new UserServiceController();
+    private static UserServiceController INSTANCE = null;
 
     /** The user manager. */
     private UserManager userManager;
@@ -83,11 +75,20 @@ public class UserServiceController {
      * @return single instance of UserServiceController
      */
     public static UserServiceController getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new UserServiceController();
+        }
         return INSTANCE;
     }
 
-    private static final PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
-    private static final RESTServicePlugin plugin = (RESTServicePlugin) pluginManager.getPlugin("restapi");
+    /**
+     * @param instance the mock/stub/spy controller to use.
+     * @deprecated - for test use only
+     */
+    @Deprecated
+    public static void setInstance(final UserServiceController instance) {
+        UserServiceController.INSTANCE = instance;
+    }
 
     /**
      * Instantiates a new user service controller.
@@ -100,8 +101,9 @@ public class UserServiceController {
     }
 
     public static void log(String logMessage) {
-        if (plugin.isServiceLoggingEnabled())
+        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
             LOG.info(logMessage);
+        }
     }
 
     /**

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersServiceBackwardCompatibilityTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.rest.service;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
+import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Asserts that service endpoints in <tt>restapi/v1/chatrooms/{roomName}/members</tt> have a stable signature.
+ *
+ * The tests in this class interact with the REST API as instantiated in this plugin, and compare the output to output
+ * that was previously recorded (at the time of test implementation) using older versions of Openfire and the REST API
+ * plugin.
+ *
+ * This test implementation instantiate the REST API using the Jersey Test framework and a mock service controller
+ * implementation, that, during implementation, has been verified to yield the same results as comparable interaction
+ * with a fully deployed Openfire server on which the REST API plugin was installed.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class MUCRoomMembersServiceBackwardCompatibilityTest extends JerseyTest {
+    /**
+     * Constructs the mock of the service controller that mimics the 'business logic' normally provided by a running
+     * Openfire server.
+     *
+     * @return A mock of a MUCRoomController
+     */
+    public static MUCRoomController constructMockController() throws ServiceException {
+        final MUCRoomController controller = mock(MUCRoomController.class, withSettings().lenient());
+
+        return controller;
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws ServiceException {
+        // Override the service controller with a mock controller.
+        MUCRoomController.setInstance(constructMockController());
+    }
+
+    @Override
+    protected Application configure() {
+        // Configures the Jersey web application. This should mimic JerseyWrapper's implementation.
+        return new ResourceConfig(MUCRoomMembersService.class, RESTExceptionMapper.class, CustomJacksonMapperProvider.class);
+    }
+
+    /**
+     * Issues a request to add new chat room member, using an XML representation POST'ed to the
+     * <tt>restapi/v1/chatrooms/{roomName}/members/{member}</tt> endpoint, and asserts HTTP response status indicates
+     * success.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used as input was verified to cause a member to be successfully added using Openfire 4.5.6
+     * with the restAPI plugin v1.4.0, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0. All of these versions
+     * returned the HTTP response status code '200'.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome to our lobby!</li>
+     * </ul>
+     *
+     * Note that the entity POST'ed to this service is empty. The service operates on query parts only.
+     */
+    @Test
+    public void addMemberXml() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/jane").request(MediaType.APPLICATION_XML).post(Entity.xml(""));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #addMemberXml()}, using a JID instead of a username on the URL.
+     */
+    @Test
+    public void addMemberJidXml() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/john@example.org").request(MediaType.APPLICATION_XML).post(Entity.xml(""));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #addMemberXml()}, but using headers defining JSON-based interaction.
+     */
+    @Test
+    public void addMemberJson() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/jane").request(MediaType.APPLICATION_JSON).post(Entity.json(""));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #addMemberJidXml()}, but using headers defining JSON-based interaction.
+     */
+    @Test
+    public void addMemberJidJson() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/john@example.org").request(MediaType.APPLICATION_JSON).post(Entity.json(""));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Issues a request remove an existing chat room member, using an DELETE request to the
+     * <tt>restapi/v1/chatrooms/{roomName}/members/{member}</tt> endpoint, and asserts HTTP response status indicates
+     * success.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used as input was verified to cause a member to be successfully added using Openfire 4.5.6
+     * with the restAPI plugin v1.4.0, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0. All of these versions
+     * returned the HTTP response status code '200'.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome to our lobby!</li>
+     *     <li>Permissions:
+     *     <ul>
+     *         <li>owners: admin@example.org</li>
+     *         <li>members: jane@example.org</li>
+     *     </ul></li>
+     * </ul>
+     */
+    @Test
+    public void removeMemberXml() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/jane").request(MediaType.APPLICATION_XML).delete();
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #removeMemberXml()}, using a JID instead of a username on the URL.
+     */
+    @Test
+    public void removeMemberJidXml() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/jane@example.org").request(MediaType.APPLICATION_XML).delete();
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #removeMemberXml()}, but using headers defining JSON-based interaction.
+     */
+    @Test
+    public void removeMemberJson() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/jane").request(MediaType.APPLICATION_JSON).delete();
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #removeMemberJidXml()}, but using headers defining JSON-based interaction.
+     */
+    @Test
+    public void removeMemberJidJson() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/jane@example.org").request(MediaType.APPLICATION_JSON).delete();
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Issues a request to add new chat room member group, using an XML representation POST'ed to the
+     * <tt>restapi/v1/chatrooms/{roomName}/members/group/{groupName}</tt> endpoint, and asserts HTTP response status
+     * indicates success.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used as input was verified to cause a member to be successfully added using Openfire 4.5.6
+     * with the restAPI plugin v1.4.0, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0. All of these versions
+     * returned the HTTP response status code '201'.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome to our lobby!</li>
+     * </ul>
+     *
+     * A group named 'test group' was created, that contained 'john@example.org' and 'jane@example.org'.
+     *
+     * Note that the entity POST'ed to this service is empty. The service operates on query parts only.
+     */
+    @Test
+    public void addMemberGroupXml() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/group/test group").request(MediaType.APPLICATION_XML).post(Entity.xml(""));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #addMemberGroupXml()}, but using headers defining JSON-based interaction.
+     */
+    @Test
+    public void addMemberGroupJson() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/group/test group").request(MediaType.APPLICATION_XML).post(Entity.xml(""));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Issues a request remove an existing chat room member group, using an DELETE request to the
+     * <tt>restapi/v1/chatrooms/{roomName}/members/group/{groupName}</tt> endpoint, and asserts HTTP response status
+     * indicates success.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used as input was verified to cause a member to be successfully added using Openfire 4.5.6
+     * with the restAPI plugin v1.4.0, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0. All of these versions
+     * returned the HTTP response status code '200'.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * A group named 'test group' was created, that contained 'john@example.org' and 'jane@example.org'.
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome to our lobby!</li>
+     *     <li>Permissions:
+     *     <ul>
+     *         <li>owners: admin@example.org</li>
+     *         <li>members: test group@example.org</li>
+     *     </ul></li>
+     * </ul>
+     */
+    @Test
+    public void removeMemberGroupXml() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/group/test group").request(MediaType.APPLICATION_XML).delete();
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * An equivalent to {@link #removeMemberGroupXml()}, but using headers defining JSON-based interaction.
+     */
+    @Test
+    public void removeMemberGroupJson() {
+        Response response = target("restapi/v1/chatrooms/lobby/members/group/test group").request(MediaType.APPLICATION_JSON).delete();
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+}

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomServiceBackwardCompatibilityTest.java
@@ -25,6 +25,8 @@ import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntities;
 import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntity;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -35,10 +37,7 @@ import javax.ws.rs.core.Response;
 import java.sql.Date;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,6 +57,8 @@ import static org.mockito.Mockito.*;
  * @author Guus der Kinderen, guus@goodbytes.nl
  */
 public class MUCRoomServiceBackwardCompatibilityTest extends JerseyTest {
+
+    private TimeZone defaultTimeZone;
 
     /**
      * Constructs the mock of the service controller that mimics the 'business logic' normally provided by a running
@@ -128,6 +129,24 @@ public class MUCRoomServiceBackwardCompatibilityTest extends JerseyTest {
     public static void setUpClass() throws ServiceException {
         // Override the service controller with a mock controller.
         MUCRoomController.setInstance(constructMockController());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // XML timestamps will be local to the server that's running the test. Correct the local timezone to match the
+        // timezone in which the expected result was recorded, for the duration of the test.
+        defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("CET"));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        // Reset the default time zone to what it was prior to the test.
+        TimeZone.setDefault(defaultTimeZone);
     }
 
     @Override

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomServiceBackwardCompatibilityTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.rest.service;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
+import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntities;
+import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntity;
+import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntities;
+import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntity;
+import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.sql.Date;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Asserts that service endpoints in <tt>restapi/v1/chatrooms/{roomName}</tt> have a stable signature.
+ *
+ * The tests in this class interact with the REST API as instantiated in this plugin, and compare the output to output
+ * that was previously recorded (at the time of test implementation) using older versions of Openfire and the REST API
+ * plugin.
+ *
+ * This test implementation instantiate the REST API using the Jersey Test framework and a mock service controller
+ * implementation, that, during implementation, has been verified to yield the same results as comparable interaction
+ * with a fully deployed Openfire server on which the REST API plugin was installed.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class MUCRoomServiceBackwardCompatibilityTest extends JerseyTest {
+
+    /**
+     * Constructs the mock of the service controller that mimics the 'business logic' normally provided by a running
+     * Openfire server.
+     *
+     * @return A mock of a MUCRoomController
+     */
+    public static MUCRoomController constructMockController() throws ServiceException {
+        final MUCRoomController controller = mock(MUCRoomController.class, withSettings().lenient());
+
+        final MUCRoomEntity entity = new MUCRoomEntity();
+        entity.setRoomName("lobby");
+        entity.setNaturalName("Lobby");
+        entity.setDescription("Welcome in our lobby!");
+        entity.setSubject("Introduction to XMPP");
+        entity.setCreationDate(Date.from(ZonedDateTime.parse("2022-02-07T16:09:51.517+01:00", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSVV")).toInstant()));
+        entity.setModificationDate(Date.from(ZonedDateTime.parse("2022-02-07T16:09:51.538+01:00", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSVV")).toInstant()));
+        entity.setMaxUsers(30);
+        entity.setPersistent(true);
+        entity.setPublicRoom(true);
+        entity.setRegistrationEnabled(true);
+        entity.setCanAnyoneDiscoverJID(true);
+        entity.setCanOccupantsChangeSubject(false);
+        entity.setCanOccupantsInvite(false);
+        entity.setCanChangeNickname(true);
+        entity.setLogEnabled(true);
+        entity.setLoginRestrictedToNickname(false);
+        entity.setMembersOnly(false);
+        entity.setModerated(false);
+        entity.setBroadcastPresenceRoles(Arrays.asList("moderator", "participant", "visitor"));
+        entity.setOwners(Collections.singletonList("admin@example.org"));
+        entity.setAdmins(Arrays.asList("john@example.org", "jane@example.org"));
+        entity.setMembers(Collections.emptyList());
+        entity.setOutcasts(Collections.emptyList());
+        entity.setAdminGroups(Collections.emptyList());
+        entity.setOwnerGroups(Collections.emptyList());
+        entity.setMemberGroups(Collections.emptyList());
+        entity.setOutcastGroups(Collections.emptyList());
+
+        doAnswer(invocationOnMock -> new MUCRoomEntities(Collections.singletonList(entity)))
+            .when(controller).getChatRooms(any(), any(), any(), nullable(Boolean.class));
+
+        doAnswer(invocationOnMock -> entity)
+            .when(controller).getChatRoom(any(), any(), nullable(Boolean.class));
+
+        final OccupantEntity jane = new OccupantEntity();
+        jane.setJid("lobby@conference.example.org/jane");
+        jane.setUserAddress("jane@example.org/converse.js-131754909");
+        jane.setRole("participant");
+        jane.setAffiliation("member");
+
+        final OccupantEntity john = new OccupantEntity();
+        john.setJid("lobby@conference.example.org/John");
+        john.setUserAddress("john@example.org/converse.js-57890634");
+        john.setRole("participant");
+        john.setAffiliation("none");
+
+        final List<OccupantEntity> occupantEntities = new ArrayList<>();
+        occupantEntities.add(jane);
+        occupantEntities.add(john);
+
+        doAnswer(invocation -> new OccupantEntities(occupantEntities))
+            .when(controller).getRoomOccupants(any(), any());
+        return controller;
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws ServiceException {
+        // Override the service controller with a mock controller.
+        MUCRoomController.setInstance(constructMockController());
+    }
+
+    @Override
+    protected Application configure() {
+        // Configures the Jersey web application. This should mimic JerseyWrapper's implementation.
+        return new ResourceConfig(MUCRoomService.class, RESTExceptionMapper.class, CustomJacksonMapperProvider.class);
+    }
+
+    /**
+     * Retrieves an XML representation of a single chat room from the <tt>restapi/v1/chatrooms/{roomName}</tt> endpoint,
+     * and asserts that representation is equal to a representation that was recorded using an earlier version of this
+     * plugin.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used for comparison was obtained using Openfire 4.5.6 with the restAPI plugin v1.4.0. Using the
+     * restAPI plugin v1.6.0 on Openfire 4.6.1 and 4.6.7, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0 (using
+     * the same configuration of the room) yields the exact same result.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome in our lobby!</li>
+     *     <li>Topic: Introduction to XMPP</li>
+     *     <li>Permissions:
+     *     <ul>
+     *         <li>owners: admin@example.org</li>
+     *         <li>admins: jane@example.org, john@example.org</li>
+     *     </ul></li>
+     * </ul>
+     */
+    @Test
+    public void getChatRoomXml() {
+        Response response = target("restapi/v1/chatrooms/lobby").request(MediaType.APPLICATION_XML).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response should match that generated by older versions of this plugin.", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><chatRoom><roomName>lobby</roomName><naturalName>Lobby</naturalName><description>Welcome in our lobby!</description><subject>Introduction to XMPP</subject><creationDate>2022-02-07T16:09:51.517+01:00</creationDate><modificationDate>2022-02-07T16:09:51.538+01:00</modificationDate><maxUsers>30</maxUsers><persistent>true</persistent><publicRoom>true</publicRoom><registrationEnabled>true</registrationEnabled><canAnyoneDiscoverJID>true</canAnyoneDiscoverJID><canOccupantsChangeSubject>false</canOccupantsChangeSubject><canOccupantsInvite>false</canOccupantsInvite><canChangeNickname>true</canChangeNickname><logEnabled>true</logEnabled><loginRestrictedToNickname>false</loginRestrictedToNickname><membersOnly>false</membersOnly><moderated>false</moderated><broadcastPresenceRoles><broadcastPresenceRole>moderator</broadcastPresenceRole><broadcastPresenceRole>participant</broadcastPresenceRole><broadcastPresenceRole>visitor</broadcastPresenceRole></broadcastPresenceRoles><owners><owner>admin@example.org</owner></owners><admins><admin>john@example.org</admin><admin>jane@example.org</admin></admins><members/><outcasts/><ownerGroups/><adminGroups/><memberGroups/><outcastGroups/></chatRoom>", content);
+        assertEquals("HTTP response should have a status code that is 200.", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The JSON-based equivalent of {@link #getChatRoomXml()}
+     *
+     * The JSON-based output generated by restAPI plugin v1.7.0 on Openfire 4.7.0 is known to not conform to this output
+     * (which was a primary motivator for this test to be implemented).
+     *
+     * @see #getChatRoomXml()
+     * @see <a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88">REST API issue #88</a>
+     */
+    @Test
+    public void getChatRoomJson() {
+        Response response = target("restapi/v1/chatrooms/lobby").request(MediaType.APPLICATION_JSON).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response should match that generated by older versions of this plugin.", "{\"roomName\":\"lobby\",\"naturalName\":\"Lobby\",\"description\":\"Welcome in our lobby!\",\"subject\":\"Introduction to XMPP\",\"creationDate\":1644246591517,\"modificationDate\":1644246591538,\"maxUsers\":30,\"persistent\":true,\"publicRoom\":true,\"registrationEnabled\":true,\"canAnyoneDiscoverJID\":true,\"canOccupantsChangeSubject\":false,\"canOccupantsInvite\":false,\"canChangeNickname\":true,\"logEnabled\":true,\"loginRestrictedToNickname\":false,\"membersOnly\":false,\"moderated\":false,\"broadcastPresenceRoles\":[\"moderator\",\"participant\",\"visitor\"],\"owners\":[\"admin@example.org\"],\"admins\":[\"john@example.org\",\"jane@example.org\"],\"members\":[],\"outcasts\":[],\"ownerGroups\":[],\"adminGroups\":[],\"memberGroups\":[],\"outcastGroups\":[]}", content);
+        assertEquals("HTTP response should have a status code that is 200.", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Retrieves an XML representation of all chat rooms from the <tt>restapi/v1/chatrooms/</tt> endpoint, and asserts
+     * that representation is equal to a representation that was recorded using an earlier version of this plugin.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used for comparison was obtained using Openfire 4.5.6 with the restAPI plugin v1.4.0. Using the
+     * restAPI plugin v1.6.0 on Openfire 4.6.1 and 4.6.7, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0 (using
+     * the same configuration of the room) yields the exact same result.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome in our lobby!</li>
+     *     <li>Topic: Introduction to XMPP</li>
+     *     <li>Permissions:
+     *     <ul>
+     *         <li>owners: admin@example.org</li>
+     *         <li>admins: jane@example.org, john@example.org</li>
+     *     </ul></li>
+     * </ul>
+     */
+    @Test
+    public void getChatRoomsXml() {
+        Response response = target("restapi/v1/chatrooms").request(MediaType.APPLICATION_XML).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response is: ", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><chatRooms><chatRoom><roomName>lobby</roomName><naturalName>Lobby</naturalName><description>Welcome in our lobby!</description><subject>Introduction to XMPP</subject><creationDate>2022-02-07T16:09:51.517+01:00</creationDate><modificationDate>2022-02-07T16:09:51.538+01:00</modificationDate><maxUsers>30</maxUsers><persistent>true</persistent><publicRoom>true</publicRoom><registrationEnabled>true</registrationEnabled><canAnyoneDiscoverJID>true</canAnyoneDiscoverJID><canOccupantsChangeSubject>false</canOccupantsChangeSubject><canOccupantsInvite>false</canOccupantsInvite><canChangeNickname>true</canChangeNickname><logEnabled>true</logEnabled><loginRestrictedToNickname>false</loginRestrictedToNickname><membersOnly>false</membersOnly><moderated>false</moderated><broadcastPresenceRoles><broadcastPresenceRole>moderator</broadcastPresenceRole><broadcastPresenceRole>participant</broadcastPresenceRole><broadcastPresenceRole>visitor</broadcastPresenceRole></broadcastPresenceRoles><owners><owner>admin@example.org</owner></owners><admins><admin>john@example.org</admin><admin>jane@example.org</admin></admins><members/><outcasts/><ownerGroups/><adminGroups/><memberGroups/><outcastGroups/></chatRoom></chatRooms>", content);
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The JSON-based equivalent of {@link #getChatRoomsXml()}
+     *
+     * The JSON-based output generated by restAPI plugin v1.7.0 on Openfire 4.7.0 is known to not conform to this output
+     * (which was a primary motivator for this test to be implemented).
+     *
+     * @see #getChatRoomsXml()
+     * @see <a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88">REST API issue #88</a>
+     */
+    @Test
+    public void getChatRoomsJson() {
+        Response response = target("restapi/v1/chatrooms").request(MediaType.APPLICATION_JSON).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response is: ", "{\"chatRooms\":[{\"roomName\":\"lobby\",\"naturalName\":\"Lobby\",\"description\":\"Welcome in our lobby!\",\"subject\":\"Introduction to XMPP\",\"creationDate\":1644246591517,\"modificationDate\":1644246591538,\"maxUsers\":30,\"persistent\":true,\"publicRoom\":true,\"registrationEnabled\":true,\"canAnyoneDiscoverJID\":true,\"canOccupantsChangeSubject\":false,\"canOccupantsInvite\":false,\"canChangeNickname\":true,\"logEnabled\":true,\"loginRestrictedToNickname\":false,\"membersOnly\":false,\"moderated\":false,\"broadcastPresenceRoles\":[\"moderator\",\"participant\",\"visitor\"],\"owners\":[\"admin@example.org\"],\"admins\":[\"john@example.org\",\"jane@example.org\"],\"members\":[],\"outcasts\":[],\"ownerGroups\":[],\"adminGroups\":[],\"memberGroups\":[],\"outcastGroups\":[]}]}", content);
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Issues a request to create a new chat room, using an XML representation POST'ed to the
+     * <tt>restapi/v1/chatrooms/</tt> endpoint, and asserts HTTP response status indicates success.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used as input was verified to cause a chat room to be successfully created using Openfire 4.5.6
+     * with the restAPI plugin v1.4.0, the restAPI plugin v1.6.0 on Openfire 4.6.1 and 4.6.7, as well as the restAPI
+     * plugin v1.7.0 on Openfire 4.7.0. All of these versions returned the HTTP response status code '201'.
+     */
+    @Test
+    public void createChatRoomXml() {
+        Response response = target("restapi/v1/chatrooms").request(MediaType.APPLICATION_XML).post(Entity.xml("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><chatRoom><roomName>lobby</roomName><naturalName>Lobby</naturalName><description>Welcome in our lobby!</description><subject>Introduction to XMPP</subject><maxUsers>30</maxUsers><persistent>true</persistent><publicRoom>true</publicRoom><registrationEnabled>true</registrationEnabled><canAnyoneDiscoverJID>true</canAnyoneDiscoverJID><canOccupantsChangeSubject>false</canOccupantsChangeSubject><canOccupantsInvite>false</canOccupantsInvite><canChangeNickname>true</canChangeNickname><logEnabled>true</logEnabled><loginRestrictedToNickname>false</loginRestrictedToNickname><membersOnly>false</membersOnly><moderated>false</moderated><broadcastPresenceRoles><broadcastPresenceRole>moderator</broadcastPresenceRole><broadcastPresenceRole>participant</broadcastPresenceRole><broadcastPresenceRole>visitor</broadcastPresenceRole></broadcastPresenceRoles><owners><owner>admin@example.org</owner></owners><admins><admin>john@example.org</admin><admin>jane@example.org</admin></admins><members/><outcasts/><ownerGroups/><adminGroups/><memberGroups/><outcastGroups/></chatRoom>"));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The JSON-based equivalent of {@link #createChatRoomXml()}
+     *
+     * The restAPI plugin v1.7.0 on Openfire 4.7.0 is known to not accept the value that is provided as input, although
+     * this value is accepted by older versions. This was a primary motivator for this test to be implemented.
+     *
+     * @see #createChatRoomXml()
+     * @see <a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88">REST API issue #88</a>
+     */
+    @Test
+    public void createChatRoomJson() {
+        Response response = target("restapi/v1/chatrooms").request(MediaType.APPLICATION_XML).post(Entity.json("{\"roomName\":\"lobby\",\"naturalName\":\"Lobby\",\"description\":\"Welcome in our lobby!\",\"subject\":\"Introduction to XMPP\",\"maxUsers\":30,\"persistent\":true,\"publicRoom\":true,\"registrationEnabled\":true,\"canAnyoneDiscoverJID\":true,\"canOccupantsChangeSubject\":false,\"canOccupantsInvite\":false,\"canChangeNickname\":true,\"logEnabled\":true,\"loginRestrictedToNickname\":false,\"membersOnly\":false,\"moderated\":false,\"broadcastPresenceRoles\":[\"moderator\",\"participant\",\"visitor\"],\"owners\":[\"admin@example.org\"],\"admins\":[\"john@example.org\",\"jane@example.org\"],\"members\":[],\"outcasts\":[],\"ownerGroups\":[],\"adminGroups\":[],\"memberGroups\":[],\"outcastGroups\":[]}"));
+
+        assertEquals("Http Response should be 201: ", Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Issues a request to create a new chat room, using an XML representation PUT to the
+     * <tt>restapi/v1/chatrooms/{roomName}</tt> endpoint, and asserts HTTP response status indicates success.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used as input was verified to cause a chat room to be successfully created using Openfire 4.5.6
+     * with the restAPI plugin v1.4.0, the restAPI plugin v1.6.0 on Openfire 4.6.1 and 4.6.7, as well as the restAPI
+     * plugin v1.7.0 on Openfire 4.7.0. All of these versions returned the HTTP response status code '200'.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: This will be changed!</li>
+     * </ul>
+     */
+    @Test
+    public void updateChatRoomXml() {
+        Response response = target("restapi/v1/chatrooms/lobby").request(MediaType.APPLICATION_XML).put(Entity.xml("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><chatRoom><roomName>lobby</roomName><naturalName>Lobby</naturalName><description>Welcome in our lobby!</description><subject>Introduction to XMPP</subject><maxUsers>30</maxUsers><persistent>true</persistent><publicRoom>true</publicRoom><registrationEnabled>true</registrationEnabled><canAnyoneDiscoverJID>true</canAnyoneDiscoverJID><canOccupantsChangeSubject>false</canOccupantsChangeSubject><canOccupantsInvite>false</canOccupantsInvite><canChangeNickname>true</canChangeNickname><logEnabled>true</logEnabled><loginRestrictedToNickname>false</loginRestrictedToNickname><membersOnly>false</membersOnly><moderated>false</moderated><broadcastPresenceRoles><broadcastPresenceRole>moderator</broadcastPresenceRole><broadcastPresenceRole>participant</broadcastPresenceRole><broadcastPresenceRole>visitor</broadcastPresenceRole></broadcastPresenceRoles><owners><owner>admin@example.org</owner></owners><admins><admin>john@example.org</admin><admin>jane@example.org</admin></admins><members/><outcasts/><ownerGroups/><adminGroups/><memberGroups/><outcastGroups/></chatRoom>"));
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The JSON-based equivalent of {@link #updateChatRoomXml()}
+     *
+     * The restAPI plugin v1.7.0 on Openfire 4.7.0 is known to not accept the value that is provided as input, although
+     * this value is accepted by older versions. This was a primary motivator for this test to be implemented.
+     *
+     * @see #updateChatRoomXml()
+     * @see <a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88">REST API issue #88</a>
+     */
+    @Test
+    public void updateChatRoomJson() {
+        Response response = target("restapi/v1/chatrooms/lobby").request(MediaType.APPLICATION_XML).put(Entity.json("{\"roomName\":\"lobby\",\"naturalName\":\"Lobby\",\"description\":\"Welcome in our lobby!\",\"subject\":\"Introduction to XMPP\",\"maxUsers\":30,\"persistent\":true,\"publicRoom\":true,\"registrationEnabled\":true,\"canAnyoneDiscoverJID\":true,\"canOccupantsChangeSubject\":false,\"canOccupantsInvite\":false,\"canChangeNickname\":true,\"logEnabled\":true,\"loginRestrictedToNickname\":false,\"membersOnly\":false,\"moderated\":false,\"broadcastPresenceRoles\":[\"moderator\",\"participant\",\"visitor\"],\"owners\":[\"admin@example.org\"],\"admins\":[\"john@example.org\",\"jane@example.org\"],\"members\":[],\"outcasts\":[],\"ownerGroups\":[],\"adminGroups\":[],\"memberGroups\":[],\"outcastGroups\":[]}"));
+
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * Retrieves an XML representation of all occupants in a chat room from the
+     * <tt>restapi/v1/chatrooms/{roomName}/occupants</tt> endpoint, and asserts that representation is equal to a
+     * representation that was recorded using an earlier version of this plugin.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used for comparison was obtained using Openfire 4.5.6 with the restAPI plugin v1.4.0, as well
+     * as the restAPI plugin v1.7.0 on Openfire 4.7.0 (using the same configuration of the room) yields the exact same
+     * result.
+     *
+     * The room configuration was based on a 'demoboot' server start in which a new MUC room is created, using these
+     * values (leaving everything else on default):
+     *
+     * <ul>
+     *     <li>Room ID: lobby</li>
+     *     <li>Room Name: Lobby</li>
+     *     <li>Description: Welcome in our lobby!</li>
+     *     <li>Topic: Introduction to XMPP</li>
+     *     <li>Permissions:
+     *     <ul>
+     *         <li>owners: admin@example.org</li>
+     *         <li>members: jane@example.org</li>
+     *     </ul></li>
+     * </ul>
+     *
+     * Two clients were used to have users jane (using the nickname 'jane') and users 'john' (using the nickname "John")
+     * join the room as occupants.
+     */
+    @Test
+    public void getOccupantsXml()
+    {
+        Response response = target("restapi/v1/chatrooms/lobby/occupants").request(MediaType.APPLICATION_XML).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response is: ", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><occupants><occupant><affiliation>member</affiliation><jid>lobby@conference.example.org/jane</jid><role>participant</role><userAddress>jane@example.org/converse.js-131754909</userAddress></occupant><occupant><affiliation>none</affiliation><jid>lobby@conference.example.org/John</jid><role>participant</role><userAddress>john@example.org/converse.js-57890634</userAddress></occupant></occupants>", content);
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The JSON-based equivalent of {@link #getOccupantsXml()}
+     *
+     * The JSON-based output generated by restAPI plugin v1.7.0 on Openfire 4.7.0 is known to not conform to this output
+     * (which was a primary motivator for this test to be implemented).
+     *
+     * @see #getOccupantsXml()
+     * @see <a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88">REST API issue #88</a>
+     */
+    @Test
+    public void getOccupantsJson()
+    {
+        Response response = target("restapi/v1/chatrooms/lobby/occupants").request(MediaType.APPLICATION_JSON).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response is: ", "{\"occupants\":[{\"jid\":\"lobby@conference.example.org/jane\",\"userAddress\":\"jane@example.org/converse.js-131754909\",\"role\":\"participant\",\"affiliation\":\"member\"},{\"jid\":\"lobby@conference.example.org/John\",\"userAddress\":\"john@example.org/converse.js-57890634\",\"role\":\"participant\",\"affiliation\":\"none\"}]}", content);
+        assertEquals("Http Response should be 200: ", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+}

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/UserRosterServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/UserRosterServiceBackwardCompatibilityTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.rest.service;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
+import org.jivesoftware.openfire.plugin.rest.controller.UserServiceController;
+import org.jivesoftware.openfire.plugin.rest.entity.RosterEntities;
+import org.jivesoftware.openfire.plugin.rest.entity.RosterItemEntity;
+import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.jivesoftware.openfire.roster.RosterItem;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Asserts that service endpoints in <tt>restapi/v1/users/{username}/roster</tt> have a stable signature.
+ *
+ * The tests in this class interact with the REST API as instantiated in this plugin, and compare the output to output
+ * that was previously recorded (at the time of test implementation) using older versions of Openfire and the REST API
+ * plugin.
+ *
+ * This test implementation instantiate the REST API using the Jersey Test framework and a mock service controller
+ * implementation, that, during implementation, has been verified to yield the same results as comparable interaction
+ * with a fully deployed Openfire server on which the REST API plugin was installed.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class UserRosterServiceBackwardCompatibilityTest extends JerseyTest {
+
+    /**
+     * Constructs the mock of the service controller that mimics the 'business logic' normally provided by a running
+     * Openfire server.
+     *
+     * @return A mock of a UserServiceController
+     */
+    public static UserServiceController constructMockController() throws ServiceException {
+        final UserServiceController controller = mock(UserServiceController.class, withSettings().lenient());
+
+        final RosterItemEntity entity = new RosterItemEntity();
+        entity.setJid("john@example.org");
+        entity.setNickname("John");
+        entity.setGroups(Collections.emptyList());
+        entity.setSubscriptionType(RosterItem.SubType.BOTH.getValue());
+
+        doAnswer(invocationOnMock -> new RosterEntities(Collections.singletonList(entity)))
+            .when(controller).getRosterEntities(any());
+        return controller;
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws ServiceException {
+        // Override the service controller with a mock controller.
+        UserServiceController.setInstance(constructMockController());
+    }
+
+    @Override
+    protected Application configure() {
+        // Configures the Jersey web application. This should mimic JerseyWrapper's implementation.
+        return new ResourceConfig(UserRosterService.class, RESTExceptionMapper.class, CustomJacksonMapperProvider.class);
+    }
+
+    /**
+     * Retrieves an XML representation of a user's roster from the <tt>restapi/v1/users/{username}/roster</tt> endpoint,
+     * and asserts that representation is equal to a representation that was recorded using an earlier version of this
+     * plugin.
+     *
+     * The purpose of this test is to ensure that future versions of this plugin return a value that is compatible with
+     * earlier versions of this plugin.
+     *
+     * The value that is used for comparison was obtained using Openfire 4.5.6 with the restAPI plugin v1.4.0. Using the
+     * restAPI plugin v1.6.0 on Openfire 4.6.1 and 4.6.7, as well as the restAPI plugin v1.7.0 on Openfire 4.7.0 (using
+     * the same configuration of the roster) yields the exact same result.
+     *
+     * The roster definition is based on the 'jane' user as populated in a 'demoboot' server. It contains exactly one
+     * roster item, "John" (john@example.org) without groups, in a two-way subscription state.
+     */
+    @Test
+    public void getRosterXml() {
+        Response response = target("restapi/v1/users/jane/roster").request(MediaType.APPLICATION_XML).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response should match that generated by older versions of this plugin.", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><roster><rosterItem><jid>john@example.org</jid><nickname>John</nickname><subscriptionType>3</subscriptionType><groups/></rosterItem></roster>", content);
+        assertEquals("HTTP response should have a status code that is 200.", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The JSON-based equivalent of {@link #getRosterXml()}
+     *
+     * The JSON-based output generated by restAPI plugin v1.4.0 on Openfire 4.6.4 has been reported to not conform to
+     * this output (which was a primary motivator for this test to be implemented). The author of this test has tried,
+     * but has not been able to reproduce that issue. Certain versions of the restAPI plugin contained different
+     * versions of the third party Jackson libraries (used for JSON serialization), which might account for differences
+     * in behavior between different deployments.
+     *
+     * While writing this test, it was observed that restAPI plugin v1.7.0 on Openfire 4.7.0 does not conform to any
+     * of the earlier output (the property name holding group names is singular in v1.7.0, where it is pural in older
+     * versions).
+     *
+     * @see #getRosterXml()
+     * @see <a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/79">REST API issue #79</a>
+     */
+    @Test
+    public void getChatRoomJson() {
+        Response response = target("restapi/v1/users/jane/roster").request(MediaType.APPLICATION_JSON).get();
+
+        String content = response.readEntity(String.class);
+        assertEquals("Content of response should match that generated by older versions of this plugin.", "{\"rosterItem\":[{\"jid\":\"john@example.org\",\"nickname\":\"John\",\"subscriptionType\":3,\"groups\":[]}]}", content);
+        assertEquals("HTTP response should have a status code that is 200.", Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+}


### PR DESCRIPTION
Users of the plugin benefit from a stable API: subtle changes to the input our output of the services can break third-party applications that depend on this API.

To help ensure that the API does not change, this commit introduces a set of Unit tests that verify the input and output of service calls, by comparing them against known-good values (collected in the past).

This is far from a finished PR (hence the 'draft' status). I'm looking for feedback on the approach.