### PR TITLE
fixes #88: JSON serialization configuration changes

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.7.1</b> (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88'>#88</a>] - Fix backwards compatibility issues introduced in release 1.7.0.</li>
+</ul>
+
 <p><b>1.7.0</b> January 19, 2022</p>
 <ul>
     <li>Requires Openfire 4.7.0</li>

--- a/src/java/org/jivesoftware/openfire/plugin/rest/CustomJacksonMapperProvider.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/CustomJacksonMapperProvider.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.plugin.rest;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
@@ -34,8 +35,10 @@ public class CustomJacksonMapperProvider implements ContextResolver<ObjectMapper
     public CustomJacksonMapperProvider() {
         mapper = new ObjectMapper();
 
-        // Configure Jackson to use JAXB annotations as the primary, and  Jackson annotations as the secondary source.
-        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        // Configure Jackson to use JAXB annotations as the secondary, and Jackson annotations as the primary source.
+        mapper.registerModule(new JaxbAnnotationModule().setPriority(JaxbAnnotationModule.Priority.SECONDARY));
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/OccupantEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/OccupantEntity.java
@@ -57,6 +57,7 @@ public class OccupantEntity {
         this.affiliation = affiliation;
     }
 
+    @XmlElement
     public String getUserAddress() {
         return userAddress;
     }


### PR DESCRIPTION
Prior to release 1.7.0, the JSON representation of entities did not include fields that hold null values.

Also, where both JAXB XmlElementWrapper and XmlElement annotations are used, the existing config will use the JAXB XmlElementWrapper annotation for JSON serialization, which hold a value that causes the resulting JSON value to be different from earlier versions. To make sure the correct value is used, this commit ensures that Jackson annotations are preferred over JAXB annotations. As long as Jackson annotations are present, the correct result will be generated.

Ideally, this PR is rebased on top of https://github.com/igniterealtime/openfire-restAPI-plugin/pull/89 or the other way around (which should add tests that verify the expected behavior).