### PR TITLE
Release 1.7.1

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,7 +44,7 @@
 REST API Plugin Changelog
 </h1>
 
-<p><b>1.7.1</b> (tbd)</p>
+<p><b>1.7.1</b> February 14, 2022</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/88'>#88</a>] - Fix backwards compatibility issues introduced in release 1.7.0.</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>01/19/2022</date>
+    <date>02/14/2022</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.1</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2-SNAPSHOT</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     <licenses>


### PR DESCRIPTION
I'd like to not wait to long to push out 1.7.1. As this release fixes backwards compatibility issues introduced in 1.7.0, I'm eager to make 1.7.0 no longer be the last release (and thus try to minimize the amount of people that adopt to the syntax in that version.

This PR should be rebased/merged, but _not_ squashed. A release should be drafted on the first commit of this PR.