### PR TITLE
fixes #92: add endpoints for readiness and liveness checks

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ REST API Plugin Changelog
 <p><b>1.7.2</b> (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/76'>#76</a>] - Add a clustering status endpoint</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/92'>#92</a>] - Add endpoints for readiness and liveness.</li>
 </ul>
 
 <p><b>1.7.1</b> February 14, 2022</p>

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.plugin.rest.controller;
+
+import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
+import org.jivesoftware.openfire.plugin.rest.entity.SystemProperties;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SystemController {
+    private static final Logger LOG = LoggerFactory.getLogger(SystemController.class);
+
+    private static SystemController INSTANCE = null;
+
+    /**
+     * Gets the single instance of SystemController.
+     *
+     * @return single instance of SystemController
+     */
+    public static SystemController getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SystemController();
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * @param instance the mock/stub/spy controller to use.
+     * @deprecated - for test use only
+     */
+    @Deprecated
+    public static void setInstance(final SystemController instance) {
+        SystemController.INSTANCE = instance;
+    }
+
+    public static void log(String logMessage) {
+        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+            LOG.info(logMessage);
+        }
+    }
+
+    /**
+     * Gets the system properties.
+     *
+     * @return the system properties
+     */
+    public SystemProperties getSystemProperties() {
+        final Collection<SystemProperty> systemProperties = org.jivesoftware.util.SystemProperty.getProperties();
+        final Set<String> systemPropertyKeys = systemProperties.stream().map(org.jivesoftware.util.SystemProperty::getKey).collect(Collectors.toSet());
+        // Get all the SystemProperties
+        final List<org.jivesoftware.openfire.plugin.rest.entity.SystemProperty> compoundProperties = systemProperties.stream().map(p -> new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(p.getKey(), p.getValueAsSaved())).collect(Collectors.toList());
+        // Now add any missing JiveGlobals properties
+        JiveGlobals.getPropertyNames().stream().filter(key -> !systemPropertyKeys.contains(key)).forEach(key -> compoundProperties.add(new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(key, JiveGlobals.getProperty(key))));
+        // And sort by key
+        compoundProperties.sort(Comparator.comparing(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty::getKey));
+
+        SystemProperties result = new SystemProperties();
+        result.setProperties(compoundProperties);
+        return result;
+    }
+
+    /**
+     * Gets the system property.
+     *
+     * @param propertyKey the property key
+     * @return the system property
+     * @throws ServiceException the service exception
+     */
+    public org.jivesoftware.openfire.plugin.rest.entity.SystemProperty getSystemProperty(String propertyKey) throws ServiceException {
+        String propertyValue = JiveGlobals.getProperty(propertyKey);
+        if(propertyValue != null) {
+            return new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(propertyKey, propertyValue);
+        } else {
+            throw new ServiceException("Could not find property", propertyKey, ExceptionType.PROPERTY_NOT_FOUND,
+                Response.Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Creates the system property.
+     *
+     * @param systemProperty the system property
+     */
+    public void createSystemProperty(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) {
+        JiveGlobals.setProperty(systemProperty.getKey(), systemProperty.getValue());
+    }
+
+    /**
+     * Delete system property.
+     *
+     * @param propertyKey the property key
+     * @throws ServiceException the service exception
+     */
+    public void deleteSystemProperty(String propertyKey) throws ServiceException {
+        if(JiveGlobals.getProperty(propertyKey) != null) {
+            JiveGlobals.deleteProperty(propertyKey);
+        } else {
+            throw new ServiceException("Could not find property", propertyKey, ExceptionType.PROPERTY_NOT_FOUND,
+                Response.Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Update system property.
+     *
+     * @param propertyKey the property key
+     * @param systemProperty the system property
+     * @throws ServiceException the service exception
+     */
+    public void updateSystemProperty(String propertyKey, org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) throws ServiceException {
+        if(JiveGlobals.getProperty(propertyKey) != null) {
+            if(systemProperty.getKey().equals(propertyKey)) {
+                JiveGlobals.setProperty(propertyKey, systemProperty.getValue());
+            } else {
+                throw new ServiceException("Path property name and entity property name doesn't match", propertyKey, ExceptionType.ILLEGAL_ARGUMENT_EXCEPTION,
+                    Response.Status.BAD_REQUEST);
+            }
+        } else {
+            throw new ServiceException("Could not find property for update", systemProperty.getKey(), ExceptionType.PROPERTY_NOT_FOUND,
+                Response.Status.NOT_FOUND);
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
@@ -250,6 +250,10 @@ public class SystemController {
                 if (listener == null) {
                     return false;
                 }
+                // When disabled, the listener immediately is in the state that we expect it to be in.
+                // If the listener is disabled, the check to see if it is 'ready' should pass.
+                // If the check does not pass when a listener is disabled, then this test will always indicate that the
+                // server isn't ready to be used.
                 return !listener.isEnabled() || listener.getSocketAcceptor() != null;
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
@@ -107,7 +107,7 @@ public class JerseyWrapper extends ResourceConfig {
             MUCRoomOutcastsService.class,
             MUCRoomOwnersService.class,
             MUCRoomService.class,
-            RestAPIService.class,
+            SystemService.class,
             SecurityAuditLogService.class,
             SessionService.class,
             StatisticsService.class,

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/RestAPIService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/RestAPIService.java
@@ -33,7 +33,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("restapi/v1/system/properties")
+@Path("restapi/v1/system")
 @Tag(name = "System", description = "Managing Openfire system configuration")
 public class RestAPIService {
 
@@ -45,6 +45,7 @@ public class RestAPIService {
     }
 
     @GET
+    @Path("/properties")
     @Operation( summary = "Get system properties",
         description = "Get all Openfire system properties.",
         responses = {
@@ -56,7 +57,7 @@ public class RestAPIService {
     }
 
     @GET
-    @Path("/{propertyKey}")
+    @Path("/properties/{propertyKey}")
     @Operation( summary = "Get system property",
         description = "Get a specific Openfire system property.",
         responses = {
@@ -72,6 +73,7 @@ public class RestAPIService {
     }
 
     @POST
+    @Path("/properties")
     @Operation( summary = "Create system property",
         description = "Create a new Openfire system property. Will overwrite a pre-existing system property that uses the same name.",
         responses = {
@@ -87,7 +89,7 @@ public class RestAPIService {
     }
 
     @PUT
-    @Path("/{propertyKey}")
+    @Path("/properties/{propertyKey}")
     @Operation( summary = "Update system property",
         description = "Updates an existing Openfire system property.",
         responses = {
@@ -106,7 +108,7 @@ public class RestAPIService {
     }
 
     @DELETE
-    @Path("/{propertyKey}")
+    @Path("/properties/{propertyKey}")
     @Operation( summary = "Remove system property",
         description = "Removes an existing Openfire system property.",
         responses = {

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/RestAPIService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/RestAPIService.java
@@ -23,12 +23,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
+import org.jivesoftware.openfire.plugin.rest.controller.SystemController;
 import org.jivesoftware.openfire.plugin.rest.entity.SystemProperties;
 import org.jivesoftware.openfire.plugin.rest.entity.SystemProperty;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 
-import javax.annotation.PostConstruct;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -36,13 +35,6 @@ import javax.ws.rs.core.Response;
 @Path("restapi/v1/system")
 @Tag(name = "System", description = "Managing Openfire system configuration")
 public class RestAPIService {
-
-    private RESTServicePlugin plugin;
-
-    @PostConstruct
-    public void init() {
-        plugin = RESTServicePlugin.getInstance();
-    }
 
     @GET
     @Path("/properties")
@@ -53,7 +45,7 @@ public class RestAPIService {
         })
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public SystemProperties getSystemProperties() {
-        return plugin.getSystemProperties();
+        return SystemController.getInstance().getSystemProperties();
     }
 
     @GET
@@ -69,7 +61,7 @@ public class RestAPIService {
             @Parameter(description = "The name of the system property to return.", example = "foo.bar.xyz", required = true) @PathParam("propertyKey") String propertyKey)
         throws ServiceException
     {
-        return plugin.getSystemProperty(propertyKey);
+        return SystemController.getInstance().getSystemProperty(propertyKey);
     }
 
     @POST
@@ -84,7 +76,7 @@ public class RestAPIService {
             @RequestBody(description = "The system property to create.", required = true) SystemProperty systemProperty)
         throws ServiceException
     {
-        plugin.createSystemProperty(systemProperty);
+        SystemController.getInstance().createSystemProperty(systemProperty);
         return Response.status(Response.Status.CREATED).build();
     }
 
@@ -103,7 +95,7 @@ public class RestAPIService {
             @RequestBody(description = "The new system property definition that replaced an existing definition.", required = true) SystemProperty systemProperty)
         throws ServiceException
     {
-        plugin.updateSystemProperty(propertyKey, systemProperty);
+        SystemController.getInstance().updateSystemProperty(propertyKey, systemProperty);
         return Response.status(Response.Status.OK).build();
     }
 
@@ -119,7 +111,7 @@ public class RestAPIService {
             @Parameter(description = "The name of the system property to delete.", example = "foo.bar.xyz", required = true) @PathParam("propertyKey") String propertyKey)
         throws ServiceException
     {
-        plugin.deleteSystemProperty(propertyKey);
+        SystemController.getInstance().deleteSystemProperty(propertyKey);
         return Response.status(Response.Status.OK).build();
     }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
@@ -34,7 +34,7 @@ import javax.ws.rs.core.Response;
 
 @Path("restapi/v1/system")
 @Tag(name = "System", description = "Managing Openfire system configuration")
-public class RestAPIService {
+public class SystemService {
 
     @GET
     @Path("/properties")

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
@@ -243,7 +243,7 @@ public class SystemService {
     @GET
     @Path("/readiness/connections")
     @Operation( summary = "Perform 'connections' readiness check",
-        description = "Detects if Openfire is ready accepting connection requests.",
+        description = "Detects if Openfire is ready to accept connection requests.",
         responses = {
             @ApiResponse(responseCode = "200", description = "The system is ready."),
             @ApiResponse(responseCode = "400", description = "The provided connectionType value is invalid."),
@@ -251,7 +251,7 @@ public class SystemService {
         })
     public Response readinessConnections(
         @Parameter(description = "Optional. Use to limit the check to one particular connection type. One of: SOCKET_S2S, SOCKET_C2S, BOSH_C2S, WEBADMIN, COMPONENT, CONNECTION_MANAGER", example = "SOCKET_C2S", required = false) @QueryParam("connectionType") String connectionType,
-        @Parameter(description = "Check the encrypted (true) or unencrypted (false) variant of the connection type. Only used in combination with 'connectionType'.", required = false) @QueryParam("servicename") Boolean encrypted
+        @Parameter(description = "Check the encrypted (true) or unencrypted (false) variant of the connection type. Only used in combination with 'connectionType', as without it, all types and both encrypted and unencrypted are checked.", required = false) @QueryParam("encrypted") Boolean encrypted
     ) {
         if (connectionType != null && !connectionType.isEmpty()) {
             // Limit check to one connection listener.
@@ -264,7 +264,7 @@ public class SystemService {
                 return Response.status(Response.Status.BAD_REQUEST).build();
             }
         } else {
-            // Check all connection listeners.
+            // Check all connection listeners, encrypted and unencrypted.
             if (!SystemController.getInstance().areConnectionListenersStarted()) {
                 return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
             }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
@@ -27,6 +27,7 @@ import org.jivesoftware.openfire.plugin.rest.controller.SystemController;
 import org.jivesoftware.openfire.plugin.rest.entity.SystemProperties;
 import org.jivesoftware.openfire.plugin.rest.entity.SystemProperty;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.jivesoftware.openfire.spi.ConnectionType;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -112,6 +113,162 @@ public class SystemService {
         throws ServiceException
     {
         SystemController.getInstance().deleteSystemProperty(propertyKey);
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/liveness")
+    @Operation( summary = "Perform all liveness checks",
+        description = "Detects if Openfire has reached a state that it cannot recover from, except for with a restart, based on every liveness check that it has implemented.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is live."),
+            @ApiResponse(responseCode = "503", description = "At least one liveness check failed: the system is determined to not be alive.")
+        })
+    public Response liveness() {
+        // Try to execute these in the order of resource usage.
+        if (SystemController.getInstance().hasDeadlock()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        if (SystemController.getInstance().hasSystemPropertyRequiringRestart()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/liveness/deadlock")
+    @Operation( summary = "Perform 'deadlock' liveness check.",
+        description = "Detects if Openfire has reached a state that it cannot recover from because of a deadlock.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is live."),
+            @ApiResponse(responseCode = "503", description = "A deadlock is detected.")
+        })
+    public Response livenessDeadlock() {
+        // Try to execute these in the order of resource usage.
+        if (SystemController.getInstance().hasDeadlock()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/liveness/properties")
+    @Operation( summary = "Perform 'properties' liveness check.",
+        description = "Detects if Openfire has reached a state that it cannot recover from because a system property change requires a restart to take effect.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is live."),
+            @ApiResponse(responseCode = "503", description = "One or more system property changes that require a server restart have been detected.")
+        })
+    public Response livenessSystemProperties() {
+        // Try to execute these in the order of resource usage.
+        if (SystemController.getInstance().hasSystemPropertyRequiringRestart()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/readiness")
+    @Operation( summary = "Perform all readiness checks",
+        description = "Detects if Openfire is in a state where it is ready to process traffic, based on every readiness check that it has implemented.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is ready."),
+            @ApiResponse(responseCode = "503", description = "At least one readiness check failed: the system is determined to not be able to process traffic.")
+        })
+    public Response readiness() {
+        // Try to execute these in the order of resource usage.
+        if (!SystemController.getInstance().isStarted()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        if (!SystemController.getInstance().hasClusteringStartedWhenEnabled()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        if (!SystemController.getInstance().hasPluginManagerExecuted()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        if (!SystemController.getInstance().areConnectionListenersStarted()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/readiness/server")
+    @Operation( summary = "Perform 'server started' readiness check",
+        description = "Detects if Openfire's core service has been started.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is ready."),
+            @ApiResponse(responseCode = "503", description = "The Openfire service has not finished starting up yet.")
+        })
+    public Response readinessServerStart() {
+        // Try to execute these in the order of resource usage.
+        if (!SystemController.getInstance().isStarted()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/readiness/cluster")
+    @Operation( summary = "Perform 'cluster' readiness check",
+        description = "Detects if the cluster functionality has finished starting (or is disabled).",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is ready."),
+            @ApiResponse(responseCode = "503", description = "Clustering functionality is enabled, but has not finished starting up yet.")
+        })
+    public Response readinessCluster() {
+        // Try to execute these in the order of resource usage.
+        if (!SystemController.getInstance().hasClusteringStartedWhenEnabled()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/readiness/plugins")
+    @Operation( summary = "Perform 'plugins' readiness check",
+        description = "Detects if Openfire has finished starting its plugins.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is ready."),
+            @ApiResponse(responseCode = "503", description = "Plugins have not all been started yet.")
+        })
+    public Response readinessPlugins() {
+        // Try to execute these in the order of resource usage.
+        if (!SystemController.getInstance().hasPluginManagerExecuted()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
+    }
+
+    @GET
+    @Path("/readiness/connections")
+    @Operation( summary = "Perform 'connections' readiness check",
+        description = "Detects if Openfire is ready accepting connection requests.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "The system is ready."),
+            @ApiResponse(responseCode = "400", description = "The provided connectionType value is invalid."),
+            @ApiResponse(responseCode = "503", description = "Openfire currently does not accept (all) connections.")
+        })
+    public Response readinessConnections(
+        @Parameter(description = "Optional. Use to limit the check to one particular connection type. One of: SOCKET_S2S, SOCKET_C2S, BOSH_C2S, WEBADMIN, COMPONENT, CONNECTION_MANAGER", example = "SOCKET_C2S", required = false) @QueryParam("connectionType") String connectionType,
+        @Parameter(description = "Check the encrypted (true) or unencrypted (false) variant of the connection type. Only used in combination with 'connectionType'.", required = false) @QueryParam("servicename") Boolean encrypted
+    ) {
+        if (connectionType != null && !connectionType.isEmpty()) {
+            // Limit check to one connection listener.
+            try {
+                ConnectionType limitToType = ConnectionType.valueOf(connectionType);
+                if (!SystemController.getInstance().isConnectionListenerStartedWhenEnabled(limitToType, encrypted)) {
+                    return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+                }
+            } catch (Throwable t) {
+                return Response.status(Response.Status.BAD_REQUEST).build();
+            }
+        } else {
+            // Check all connection listeners.
+            if (!SystemController.getInstance().areConnectionListenersStarted()) {
+                return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+            }
+        }
         return Response.status(Response.Status.OK).build();
     }
 }


### PR DESCRIPTION
Adds endpoints that perform checks for 'readiness' of Openfire (to accept data), and 'liveness' (to check if Openfire is in a state where it needs a reboot). See issue #92 for more details.

An endpoint is added for each individual check. Additionally, and endpoint has also been added that performs all checks of a particular type.