### PR TITLE
Regenerated readme.html from readme.md

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
 
@@ -16,6 +15,8 @@
         <ul>
             <li><a href="#rest-api-plugin-readme">REST API Plugin Readme</a>
                 <ul>
+                    <li><a href="#ci-build-status">CI Build Status</a></li>
+                    <li><a href="#reporting-issues">Reporting Issues</a></li>
                     <li><a href="#feature-list">Feature list</a></li>
                     <li><a href="#available-rest-api-clients">Available REST API clients</a></li>
                     <li><a href="#installation">Installation</a></li>
@@ -26,54 +27,62 @@
             <li><a href="#user-related-rest-endpoints">User related REST Endpoints</a>
                 <ul>
                     <li><a href="#retrieve-users">Retrieve users</a></li>
-                    <li><a href="#retrieve-a-user">Retrieve a user</a></li>
+                    <li><a href="#retrieve-a-user-endpoint-to-get-information-over-a-specific-user">Retrieve a user Endpoint to get information over a specific user</a></li>
                     <li><a href="#create-a-user">Create a user</a></li>
                     <li><a href="#delete-a-user">Delete a user</a></li>
                     <li><a href="#update-a-user">Update a user</a></li>
-                    <li><a href="#retrieve-all-user-groups">Retrieve all user groups</a></li>
+                    <li><a href="#retrieve-all-user-groups-endpoint-to-get-group-names-of-a-specific-user">Retrieve all user groups Endpoint to get group names of a specific user</a></li>
                     <li><a href="#add-user-to-groups">Add user to groups</a></li>
                     <li><a href="#add-user-to-group">Add user to group</a></li>
                     <li><a href="#delete-a-user-from-a-groups">Delete a user from a groups</a></li>
                     <li><a href="#delete-a-user-from-a-group">Delete a user from a group</a></li>
                     <li><a href="#lockout-a-user">Lockout a user</a></li>
-                    <li><a href="#unlock-a-user">Unlock a user</a></li>
-                    <li><a href="#retrieve-user-roster">Retrieve user roster</a></li>
-                    <li><a href="#create-a-user-roster-entry">Create a user roster entry</a></li>
-                    <li><a href="#delete-a-user-roster-entry">Delete a user roster entry</a></li>
-                    <li><a href="#update-a-user-roster-entry">Update a user roster entry</a></li>
+                    <li><a href="#unlock-a-user-endpoint-to-unlock--unban-the-user">Unlock a user Endpoint to unlock / unban the user</a></li>
+                    <li><a href="#retrieve-user-roster-endpoint-to-get-roster-entries-buddies-from-a-specific-user">Retrieve user roster Endpoint to get roster entries (buddies) from a specific user</a></li>
+                    <li><a href="#create-a-user-roster-entry-endpoint-to-add-a-new-roster-entry-to-a-user">Create a user roster entry Endpoint to add a new roster entry to a user</a></li>
+                    <li><a href="#delete-a-user-roster-entry-endpoint-to-remove-a-roster-entry-from-a-user">Delete a user roster entry Endpoint to remove a roster entry from a user</a></li>
+                    <li><a href="#update-a-user-roster-entry-endpoint-to-update-a-roster-entry">Update a user roster entry Endpoint to update a roster entry</a></li>
                 </ul>
             </li>
             <li><a href="#chat-room-related-rest-endpoints">Chat room related REST Endpoints</a>
                 <ul>
-                    <li><a href="#retrieve-all-chat-rooms">Retrieve all chat rooms</a></li>
+                    <li><a href="#retrieve-all-chat-rooms-endpoint-to-get-all-chat-rooms">Retrieve all chat rooms Endpoint to get all chat rooms</a></li>
                     <li><a href="#retrieve-a-chat-room">Retrieve a chat room</a></li>
-                    <li><a href="#retrieve-chat-room-participants">Retrieve chat room participants</a></li>
+                    <li><a href="#retrieve-chat-room-participants-endpoint-to-get-all-participants-with-a-role-of-specified-room.">Retrieve chat room participants Endpoint to get all participants with a role of specified room.</a></li>
                     <li><a href="#retrieve-chat-room-occupants">Retrieve chat room occupants</a></li>
                     <li><a href="#retrieve-chat-room-message-history">Retrieve chat room message history</a></li>
-                    <li><a href="#create-a-chat-room">Create a chat room</a></li>
-                    <li><a href="#delete-a-chat-room">Delete a chat room</a></li>
-                    <li><a href="#update-a-chat-room">Update a chat room</a></li>
+                    <li><a href="#create-a-chat-room-endpoint-to-create-a-new-chat-room.">Create a chat room Endpoint to create a new chat room.</a></li>
+                    <li><a href="#delete-a-chat-room-endpoint-to-delete-a-chat-room.">Delete a chat room Endpoint to delete a chat room.</a></li>
+                    <li><a href="#update-a-chat-room-endpoint-to-update-a-chat-room.">Update a chat room Endpoint to update a chat room.</a></li>
                     <li><a href="#invite-user-to-a-chat-room">Invite user to a chat Room</a></li>
                     <li><a href="#add-user-with-role-to-chat-room">Add user with role to chat room</a></li>
                     <li><a href="#add-group-with-role-to-chat-room">Add group with role to chat room</a></li>
-                    <li><a href="#delete-a-user-from-a-chat-room">Delete a user from a chat room</a></li>
+                    <li><a href="#delete-a-user-from-a-chat-room-endpoint-to-remove-a-room-user-role.">Delete a user from a chat room Endpoint to remove a room user role.</a></li>
                 </ul>
             </li>
             <li><a href="#system-related-rest-endpoints">System related REST Endpoints</a>
                 <ul>
-                    <li><a href="#retrieve-all-system-properties">Retrieve all system properties</a></li>
-                    <li><a href="#retrieve-system-property">Retrieve system property</a></li>
-                    <li><a href="#create-a-system-property">Create a system property</a></li>
+                    <li><a href="#retrieve-all-system-properties-endpoint-to-get-all-system-properties">Retrieve all system properties Endpoint to get all system properties</a></li>
+                    <li><a href="#retrieve-system-property-endpoint-to-get-information-over-specific-system-property">Retrieve system property Endpoint to get information over specific system property</a></li>
+                    <li><a href="#create-a-system-property-endpoint-to-create-a-system-property">Create a system property Endpoint to create a system property</a></li>
                     <li><a href="#delete-a-system-property">Delete a system property</a></li>
                     <li><a href="#update-a-system-property">Update a system property</a></li>
                     <li><a href="#retrieve-concurrent-sessions">Retrieve concurrent sessions</a></li>
+                    <li><a href="#check-the-liveness-state-using-all-checks">Check the ‘liveness’ state (using all checks)</a></li>
+                    <li><a href="#perform-deadlock-liveness-check">Perform ‘deadlock’ liveness check</a></li>
+                    <li><a href="#perform-properties-liveness-check">Perform ‘properties’ liveness check</a></li>
+                    <li><a href="#check-the-readiness-state-using-all-checks">Check the ‘readiness’ state (using all checks)</a></li>
+                    <li><a href="#perform-server-readiness-check">Perform ‘server’ readiness check</a></li>
+                    <li><a href="#perform-cluster-readiness-check">Perform ‘cluster’ readiness check</a></li>
+                    <li><a href="#perform-plugins-readiness-check">Perform ‘plugins’ readiness check</a></li>
+                    <li><a href="#perform-connections-readiness-check">Perform ‘connections’ readiness check</a></li>
                 </ul>
             </li>
             <li><a href="#group-related-rest-endpoints">Group related REST Endpoints</a>
                 <ul>
-                    <li><a href="#retrieve-all-groups">Retrieve all groups</a></li>
-                    <li><a href="#retrieve-a-group">Retrieve a group</a></li>
-                    <li><a href="#create-a-group">Create a group</a></li>
+                    <li><a href="#retrieve-all-groups-endpoint-to-get-all-groups">Retrieve all groups Endpoint to get all groups</a></li>
+                    <li><a href="#retrieve-a-group-endpoint-to-get-information-over-specific-group">Retrieve a group Endpoint to get information over specific group</a></li>
+                    <li><a href="#create-a-group-endpoint-to-create-a-new-group">Create a group Endpoint to create a new group</a></li>
                     <li><a href="#delete-a-group">Delete a group</a></li>
                     <li><a href="#update-a-group">Update a group</a></li>
                 </ul>
@@ -93,6 +102,13 @@
             <li><a href="#security-audit-related-rest-endpoints">Security Audit related REST Endpoints</a>
                 <ul>
                     <li><a href="#retrieve-the-security-audit-logs">Retrieve the Security audit logs</a></li>
+                </ul>
+            </li>
+            <li><a href="#clustering-related-rest-endpoints">Clustering related REST Endpoints</a>
+                <ul>
+                    <li><a href="#retrieve-information-for-all-cluster-nodes.">Retrieve information for all cluster nodes.</a></li>
+                    <li><a href="#retrieve-information-for-a-specific-cluster-node.">Retrieve information for a specific cluster node.</a></li>
+                    <li><a href="#retrieve-the-clustering-status">Retrieve the Clustering status</a></li>
                 </ul>
             </li>
             <li><a href="#data-format">Data format</a>
@@ -118,6 +134,10 @@
     <div class="stackedit__html">
         <h1 id="rest-api-plugin-readme">REST API Plugin Readme</h1>
         <p>The REST API Plugin provides the ability to manage Openfire by sending an REST/HTTP request to the server. This plugin’s functionality is useful for applications that need to administer Openfire outside of the Openfire admin console.</p>
+        <h2 id="ci-build-status">CI Build Status</h2>
+        <p><a href="https://github.com/igniterealtime/openfire-restAPI-plugin/actions"><img src="https://github.com/igniterealtime/openfire-restAPI-plugin/workflows/Java%20CI/badge.svg" alt="Build Status"></a></p>
+        <h2 id="reporting-issues">Reporting Issues</h2>
+        <p>Issues may be reported to the <a href="https://discourse.igniterealtime.org">forums</a> or via this repo’s <a href="https://github.com/igniterealtime/openfire-restAPI-plugin">Github Issues</a>.</p>
         <h2 id="feature-list">Feature list</h2>
         <ul>
             <li>Get overview over all or specific user and to create, update or delete a user</li>
@@ -131,6 +151,8 @@
             <li>Send broadcast message to all online users</li>
             <li>Get overview of all or specific security audit logs</li>
             <li>Get chat message history from a multi user chat room</li>
+            <li>Get clustering status of Openfire</li>
+            <li>Get overview of ‘readiness’ and ‘liveness’ state of Openfire</li>
         </ul>
         <h2 id="available-rest-api-clients">Available REST API clients</h2>
         <p>REST API clients are implementations of the REST API in a specific programming language.</p>
@@ -184,19 +206,25 @@
         <p>The configuration can be done in Openfire Admin console under Server &gt; Server Settings &gt; REST API.</p>
         <h3 id="basic-http-authentication">Basic HTTP Authentication</h3>
         <p>To access the endpoints is that required to send the Username and Password of a Openfire Admin account in your HTTP header request.</p>
-        <p>E.g. <strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=  (username: admin / password: 12345)</p>
+        <p>E.g., for username: admin and password: 12345:</p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+        </blockquote>
         <h3 id="shared-secret-key">Shared secret key</h3>
         <p>To access the endpoints is that required to send the secret key in your header request.<br>
             The secret key can be defined in Openfire Admin console under Server &gt; Server Settings &gt; REST API.</p>
-        <p>E.g. <strong>Header:</strong> Authorization: s3cretKey</p>
+        <p>E.g.</p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: s3cretKey</p>
+        </blockquote>
         <h1 id="user-related-rest-endpoints">User related REST Endpoints</h1>
         <h2 id="retrieve-users">Retrieve users</h2>
         <p>Endpoint to get all or filtered users</p>
         <blockquote>
             <p><strong>GET</strong> /users</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Users</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Users</p>
         <h3 id="possible-parameters">Possible parameters</h3>
 
         <table>
@@ -233,19 +261,24 @@
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
         </blockquote>
         <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users">http://example.org:9090/plugins/restapi/v1/users</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users?search=testuser">http://example.org:9090/plugins/restapi/v1/users?search=testuser</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname">http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname&amp;propertyValue=keyvalue">http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname&amp;propertyValue=keyvalue</a></p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users">http://example.org:9090/plugins/restapi/v1/users</a></p>
+        </blockquote>
+        <blockquote>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users?search=testuser">http://example.org:9090/plugins/restapi/v1/users?search=testuser</a></p>
+        </blockquote>
+        <blockquote>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname">http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname</a></p>
+        </blockquote>
+        <blockquote>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname&amp;propertyValue=keyvalue">http://example.org:9090/plugins/restapi/v1/users?propertyKey=keyname&amp;propertyValue=keyvalue</a></p>
         </blockquote>
         <p>If you want to get a JSON format result, please add “<strong>Accept: application/json</strong>” to the <strong>Header</strong>.</p>
-        <h2 id="retrieve-a-user">Retrieve a user</h2>
-        <p>Endpoint to get information over a specific user</p>
+        <h2 id="retrieve-a-user-endpoint-to-get-information-over-a-specific-user">Retrieve a user Endpoint to get information over a specific user</h2>
         <blockquote>
             <p><strong>GET</strong> /users/{username}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> User</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> User</p>
         <h3 id="possible-parameters-1">Possible parameters</h3>
 
         <table>
@@ -266,8 +299,10 @@
             </tr>
             </tbody>
         </table><h3 id="examples-1">Examples</h3>
-        <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+        </blockquote>
         <h2 id="create-a-user">Create a user</h2>
         <p>Endpoint to create a new user</p>
         <blockquote>
@@ -278,96 +313,47 @@
         <h3 id="examples-2">Examples</h3>
         <h4 id="xml-examples">XML Examples</h4>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/<strong>xml</strong></p>
-        </blockquote>
-        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>Header:</strong> Content-Type: application/<strong>xml</strong></p>
             <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users">http://example.org:9090/plugins/restapi/v1/users</a></p>
         </blockquote>
         <p><strong>Payload Example 1 (required parameters):</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>user</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>test3<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>password</span><span class="token punctuation">&gt;</span></span>p4ssword<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>password</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>test3<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>password</span><span class="token punctuation">&gt;</span></span>p4ssword<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>password</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <p><strong>Payload Example 2 (available parameters):</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>user</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>testuser<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>password</span><span class="token punctuation">&gt;</span></span>p4ssword<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>password</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>Test User<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>email</span><span class="token punctuation">&gt;</span></span>test@localhost.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>email</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>properties</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>keyname<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>anotherkey<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>properties</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>testuser<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>password</span><span class="token punctuation">&gt;</span></span>p4ssword<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>password</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>Test User<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>email</span><span class="token punctuation">&gt;</span></span>test@localhost.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>email</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>properties</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>keyname<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>anotherkey<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>properties</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h4 id="json-examples">JSON Examples</h4>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/<strong>json</strong></p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users">http://example.org:9090/plugins/restapi/v1/users</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/<strong>json</strong><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users">http://example.org:9090/plugins/restapi/v1/users</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload Example 1 (required parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"admin"</span><span class="token punctuation">,</span>
-    <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"admin"</span><span class="token punctuation">,</span> <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span><span class="token punctuation">}</span>
 </code></pre>
         <p><strong>Payload Example 2 (available parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"admin"</span><span class="token punctuation">,</span>
-    <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span><span class="token punctuation">,</span>
-    <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Administrator"</span><span class="token punctuation">,</span>
-    <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"admin@example.com"</span><span class="token punctuation">,</span>
-    <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"property"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-            <span class="token punctuation">{</span>
-                <span class="token string">"@key"</span><span class="token punctuation">:</span> <span class="token string">"console.rows_per_page"</span><span class="token punctuation">,</span>
-                <span class="token string">"@value"</span><span class="token punctuation">:</span> <span class="token string">"user-summary=8"</span>
-            <span class="token punctuation">}</span><span class="token punctuation">,</span>
-            <span class="token punctuation">{</span>
-                <span class="token string">"@key"</span><span class="token punctuation">:</span> <span class="token string">"console.order"</span><span class="token punctuation">,</span>
-                <span class="token string">"@value"</span><span class="token punctuation">:</span> <span class="token string">"session-summary=1"</span>
-            <span class="token punctuation">}</span>
-        <span class="token punctuation">]</span>
-    <span class="token punctuation">}</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"admin"</span><span class="token punctuation">,</span> <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span><span class="token punctuation">,</span> <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Administrator"</span><span class="token punctuation">,</span> <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"admin@example.com"</span><span class="token punctuation">,</span> <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"property"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token punctuation">{</span> <span class="token string">"@key"</span><span class="token punctuation">:</span> <span class="token string">"console.rows_per_page"</span><span class="token punctuation">,</span> <span class="token string">"@value"</span><span class="token punctuation">:</span> <span class="token string">"user-summary=8"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span> <span class="token string">"@key"</span><span class="token punctuation">:</span> <span class="token string">"console.order"</span><span class="token punctuation">,</span> <span class="token string">"@value"</span><span class="token punctuation">:</span> <span class="token string">"session-summary=1"</span> <span class="token punctuation">}</span> <span class="token punctuation">]</span> <span class="token punctuation">}</span><span class="token punctuation">}</span>
 </code></pre>
         <p><strong>REST API Version 1.3.0 and later - Payload Example 3 (available parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"users"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-        <span class="token punctuation">{</span>
-            <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"admin"</span><span class="token punctuation">,</span>
-            <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Administrator"</span><span class="token punctuation">,</span>
-            <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"admin@example.com"</span><span class="token punctuation">,</span>
-            <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span><span class="token punctuation">,</span>
-            <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-                <span class="token punctuation">{</span>
-                    <span class="token string">"key"</span><span class="token punctuation">:</span> <span class="token string">"console.order"</span><span class="token punctuation">,</span>
-                    <span class="token string">"value"</span><span class="token punctuation">:</span> <span class="token string">"session-summary=0"</span>
-                <span class="token punctuation">}</span>
-            <span class="token punctuation">]</span>
-        <span class="token punctuation">}</span><span class="token punctuation">,</span>
-        <span class="token punctuation">{</span>
-            <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"test"</span><span class="token punctuation">,</span>
-            <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Test"</span><span class="token punctuation">,</span>
-            <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span>
-        <span class="token punctuation">}</span>
-    <span class="token punctuation">]</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"users"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token punctuation">{</span> <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"admin"</span><span class="token punctuation">,</span> <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Administrator"</span><span class="token punctuation">,</span> <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"admin@example.com"</span><span class="token punctuation">,</span> <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span><span class="token punctuation">,</span> <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token punctuation">{</span> <span class="token string">"key"</span><span class="token punctuation">:</span> <span class="token string">"console.order"</span><span class="token punctuation">,</span> <span class="token string">"value"</span><span class="token punctuation">:</span> <span class="token string">"session-summary=0"</span> <span class="token punctuation">}</span> <span class="token punctuation">]</span> <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span> <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"test"</span><span class="token punctuation">,</span> <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Test"</span><span class="token punctuation">,</span> <span class="token string">"password"</span><span class="token punctuation">:</span> <span class="token string">"p4ssword"</span> <span class="token punctuation">}</span> <span class="token punctuation">]</span><span class="token punctuation">}</span>
 </code></pre>
         <h2 id="delete-a-user">Delete a user</h2>
         <p>Endpoint to delete a user</p>
         <blockquote>
             <p><strong>DELETE</strong> /users/{username}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-2">Possible parameters</h3>
 
         <table>
@@ -389,16 +375,18 @@
             </tbody>
         </table><h3 id="examples-3">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="update-a-user">Update a user</h2>
         <p>Endpoint to update / rename a user</p>
         <blockquote>
             <p><strong>PUT</strong> /users/{username}</p>
         </blockquote>
-        <p><strong>Payload:</strong> User<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> User</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-3">Possible parameters</h3>
 
         <table>
@@ -421,83 +409,52 @@
         </table><h3 id="examples-4">Examples</h3>
         <h4 id="xml-example">XML Example</h4>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>user</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>testuser<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>Test User edit<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>email</span><span class="token punctuation">&gt;</span></span>test@edit.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>email</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>properties</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>keyname<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>properties</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>testuser<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>Test User edit<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>email</span><span class="token punctuation">&gt;</span></span>test@edit.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>email</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>properties</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>keyname<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>properties</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h4 id="rename-example">Rename Example</h4>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/oldUsername">http://example.org:9090/plugins/restapi/v1/users/oldUsername</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/oldUsername">http://example.org:9090/plugins/restapi/v1/users/oldUsername</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>user</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>newUsername<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>Test User edit<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>email</span><span class="token punctuation">&gt;</span></span>test@edit.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>email</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>properties</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>keyname<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>properties</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>username</span><span class="token punctuation">&gt;</span></span>newUsername<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>username</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>Test User edit<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>email</span><span class="token punctuation">&gt;</span></span>test@edit.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>email</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>properties</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>keyname<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>value<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>properties</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>user</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h4 id="json-example">JSON Example</h4>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/json</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/json<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser">http://example.org:9090/plugins/restapi/v1/users/testuser</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"testuser"</span><span class="token punctuation">,</span>
-    <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Test User edit"</span><span class="token punctuation">,</span>
-    <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"test@edit.de"</span><span class="token punctuation">,</span>
-    <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"property"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-            <span class="token string">"@key"</span><span class="token punctuation">:</span> <span class="token string">"keyname"</span><span class="token punctuation">,</span>
-            <span class="token string">"@value"</span><span class="token punctuation">:</span> <span class="token string">"value"</span>
-        <span class="token punctuation">}</span>
-    <span class="token punctuation">}</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"testuser"</span><span class="token punctuation">,</span> <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Test User edit"</span><span class="token punctuation">,</span> <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"test@edit.de"</span><span class="token punctuation">,</span> <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"property"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"@key"</span><span class="token punctuation">:</span> <span class="token string">"keyname"</span><span class="token punctuation">,</span> <span class="token string">"@value"</span><span class="token punctuation">:</span> <span class="token string">"value"</span> <span class="token punctuation">}</span> <span class="token punctuation">}</span><span class="token punctuation">}</span>
 </code></pre>
         <p><strong>REST API Version 1.3.0 and later - Payload Example 2 (available parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"testuser"</span><span class="token punctuation">,</span>
-    <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Test User edit"</span><span class="token punctuation">,</span>
-    <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"test@edit.de"</span><span class="token punctuation">,</span>
-    <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-        <span class="token punctuation">{</span>
-            <span class="token string">"key"</span><span class="token punctuation">:</span> <span class="token string">"keyname"</span><span class="token punctuation">,</span>
-            <span class="token string">"value"</span><span class="token punctuation">:</span> <span class="token string">"value"</span>
-        <span class="token punctuation">}</span>
-    <span class="token punctuation">]</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"username"</span><span class="token punctuation">:</span> <span class="token string">"testuser"</span><span class="token punctuation">,</span> <span class="token string">"name"</span><span class="token punctuation">:</span> <span class="token string">"Test User edit"</span><span class="token punctuation">,</span> <span class="token string">"email"</span><span class="token punctuation">:</span> <span class="token string">"test@edit.de"</span><span class="token punctuation">,</span> <span class="token string">"properties"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token punctuation">{</span> <span class="token string">"key"</span><span class="token punctuation">:</span> <span class="token string">"keyname"</span><span class="token punctuation">,</span> <span class="token string">"value"</span><span class="token punctuation">:</span> <span class="token string">"value"</span> <span class="token punctuation">}</span> <span class="token punctuation">]</span><span class="token punctuation">}</span>
 </code></pre>
-        <h2 id="retrieve-all-user-groups">Retrieve all user groups</h2>
-        <p>Endpoint to get group names of a specific user</p>
+        <h2 id="retrieve-all-user-groups-endpoint-to-get-group-names-of-a-specific-user">Retrieve all user groups Endpoint to get group names of a specific user</h2>
         <blockquote>
             <p><strong>GET</strong> /users/{username}/groups</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Groups</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Groups</p>
         <h3 id="possible-parameters-4">Possible parameters</h3>
 
         <table>
@@ -520,17 +477,17 @@
         </table><h3 id="examples-5">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p>**GET ** <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups">http://example.org:9090/plugins/restapi/v1/users/testuser/groups</a></p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups">http://example.org:9090/plugins/restapi/v1/users/testuser/groups</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="add-user-to-groups">Add user to groups</h2>
         <p>Endpoint to add user to a groups</p>
         <blockquote>
             <p><strong>POST</strong> /users/{username}/groups</p>
         </blockquote>
-        <p><strong>Payload:</strong> Groups<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> Groups</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-5">Possible parameters</h3>
 
         <table>
@@ -552,26 +509,24 @@
             </tbody>
         </table><h3 id="examples-6">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups">http://example.org:9090/plugins/restapi/v1/users/testuser/groups</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups">http://example.org:9090/plugins/restapi/v1/users/testuser/groups</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groups</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Admins<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Support<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Admins<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Support<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h2 id="add-user-to-group">Add user to group</h2>
         <p>Endpoint to add user to a group</p>
         <blockquote>
             <p><strong>POST</strong> /users/{username}/groups/{groupName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-6">Possible parameters</h3>
 
         <table>
@@ -599,19 +554,19 @@
             </tbody>
         </table><h3 id="examples-7">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup">http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup">http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="delete-a-user-from-a-groups">Delete a user from a groups</h2>
         <p>Endpoint to remove a user from a groups</p>
         <blockquote>
             <p><strong>DELETE</strong> /users/{username}/groups</p>
         </blockquote>
-        <p><strong>Payload:</strong> Groups<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> Groups</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-7">Possible parameters</h3>
 
         <table>
@@ -633,26 +588,24 @@
             </tbody>
         </table><h3 id="examples-8">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups">http://example.org:9090/plugins/restapi/v1/users/testuser/groups</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups">http://example.org:9090/plugins/restapi/v1/users/testuser/groups</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groups</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Admins<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Support<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Admins<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>Support<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h2 id="delete-a-user-from-a-group">Delete a user from a group</h2>
         <p>Endpoint to remove a user from a group</p>
         <blockquote>
             <p><strong>DELETE</strong> /users/{username}/groups/{groupName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-8">Possible parameters</h3>
 
         <table>
@@ -680,19 +633,19 @@
             </tbody>
         </table><h3 id="examples-9">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup">http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup">http://example.org:9090/plugins/restapi/v1/users/testuser/groups/testGroup</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="lockout-a-user">Lockout a user</h2>
         <p>Endpoint to lockout / ban the user from the chat server. The user will be kicked if the user is online.</p>
         <blockquote>
             <p><strong>POST</strong> /lockouts/{username}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-9">Possible parameters</h3>
 
         <table>
@@ -715,17 +668,16 @@
         </table><h3 id="examples-10">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/lockouts/testuser">http://example.org:9090/plugins/restapi/v1/lockouts/testuser</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/lockouts/testuser">http://example.org:9090/plugins/restapi/v1/lockouts/testuser</a></p>
-        </blockquote>
-        <h2 id="unlock-a-user">Unlock a user</h2>
-        <p>Endpoint to unlock / unban the user</p>
+        <h2 id="unlock-a-user-endpoint-to-unlock--unban-the-user">Unlock a user Endpoint to unlock / unban the user</h2>
         <blockquote>
             <p><strong>DELETE</strong> /lockouts/{username}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-10">Possible parameters</h3>
 
         <table>
@@ -748,17 +700,16 @@
         </table><h3 id="examples-11">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/lockouts/testuser">http://example.org:9090/plugins/restapi/v1/lockouts/testuser</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/lockouts/testuser">http://example.org:9090/plugins/restapi/v1/lockouts/testuser</a></p>
-        </blockquote>
-        <h2 id="retrieve-user-roster">Retrieve user roster</h2>
-        <p>Endpoint to get roster entries (buddies) from a specific user</p>
+        <h2 id="retrieve-user-roster-endpoint-to-get-roster-entries-buddies-from-a-specific-user">Retrieve user roster Endpoint to get roster entries (buddies) from a specific user</h2>
         <blockquote>
             <p><strong>GET</strong> /users/{username}/roster</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Roster</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Roster</p>
         <h3 id="possible-parameters-11">Possible parameters</h3>
 
         <table>
@@ -781,17 +732,16 @@
         </table><h3 id="examples-12">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster">http://example.org:9090/plugins/restapi/v1/users/testuser/roster</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster">http://example.org:9090/plugins/restapi/v1/users/testuser/roster</a></p>
-        </blockquote>
-        <h2 id="create-a-user-roster-entry">Create a user roster entry</h2>
-        <p>Endpoint to add a new roster entry to a user</p>
+        <h2 id="create-a-user-roster-entry-endpoint-to-add-a-new-roster-entry-to-a-user">Create a user roster entry Endpoint to add a new roster entry to a user</h2>
         <blockquote>
             <p><strong>POST</strong> /users/{username}/roster</p>
         </blockquote>
-        <p><strong>Payload:</strong> RosterItem<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> RosterItem</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-12">Possible parameters</h3>
 
         <table>
@@ -813,37 +763,29 @@
             </tbody>
         </table><h3 id="examples-13">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster">http://example.org:9090/plugins/restapi/v1/users/testuser/roster</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster">http://example.org:9090/plugins/restapi/v1/users/testuser/roster</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong><br>
             Payload Example 1 (required parameters):</p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>jid</span><span class="token punctuation">&gt;</span></span>peter@pan.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>jid</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>jid</span><span class="token punctuation">&gt;</span></span>peter@pan.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>jid</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <p>Payload Example 2 (available parameters):</p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>jid</span><span class="token punctuation">&gt;</span></span>peter@pan1.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>jid</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>nickname</span><span class="token punctuation">&gt;</span></span>Peter1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>nickname</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subscriptionType</span><span class="token punctuation">&gt;</span></span>3<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subscriptionType</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groups</span><span class="token punctuation">&gt;</span></span>
-		<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>Friends<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>jid</span><span class="token punctuation">&gt;</span></span>peter@pan1.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>jid</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>nickname</span><span class="token punctuation">&gt;</span></span>Peter1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>nickname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subscriptionType</span><span class="token punctuation">&gt;</span></span>3<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subscriptionType</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groups</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>Friends<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
-        <h2 id="delete-a-user-roster-entry">Delete a user roster entry</h2>
-        <p>Endpoint to remove a roster entry from a user</p>
+        <h2 id="delete-a-user-roster-entry-endpoint-to-remove-a-roster-entry-from-a-user">Delete a user roster entry Endpoint to remove a roster entry from a user</h2>
         <blockquote>
             <p><strong>DELETE</strong> /users/{username}/roster/{jid}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-13">Possible parameters</h3>
 
         <table>
@@ -872,17 +814,16 @@
         </table><h3 id="examples-14">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de">http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de">http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de</a></p>
-        </blockquote>
-        <h2 id="update-a-user-roster-entry">Update a user roster entry</h2>
-        <p>Endpoint to update a roster entry</p>
+        <h2 id="update-a-user-roster-entry-endpoint-to-update-a-roster-entry">Update a user roster entry Endpoint to update a roster entry</h2>
         <blockquote>
             <p><strong>PUT</strong> /users/{username}/roster/{jid}</p>
         </blockquote>
-        <p><strong>Payload:</strong> RosterItem<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> RosterItem</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-14">Possible parameters</h3>
 
         <table>
@@ -910,31 +851,24 @@
             </tbody>
         </table><h3 id="examples-15">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de">http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de">http://example.org:9090/plugins/restapi/v1/users/testuser/roster/peter@pan.de</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>jid</span><span class="token punctuation">&gt;</span></span>peter@pan.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>jid</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>nickname</span><span class="token punctuation">&gt;</span></span>Peter Pan<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>nickname</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subscriptionType</span><span class="token punctuation">&gt;</span></span>0<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subscriptionType</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groups</span><span class="token punctuation">&gt;</span></span>
-		<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>Support<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>jid</span><span class="token punctuation">&gt;</span></span>peter@pan.de<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>jid</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>nickname</span><span class="token punctuation">&gt;</span></span>Peter Pan<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>nickname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subscriptionType</span><span class="token punctuation">&gt;</span></span>0<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subscriptionType</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groups</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>Support<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groups</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>rosterItem</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h1 id="chat-room-related-rest-endpoints">Chat room related REST Endpoints</h1>
-        <h2 id="retrieve-all-chat-rooms">Retrieve all chat rooms</h2>
-        <p>Endpoint to get all chat rooms</p>
+        <h2 id="retrieve-all-chat-rooms-endpoint-to-get-all-chat-rooms">Retrieve all chat rooms Endpoint to get all chat rooms</h2>
         <blockquote>
             <p><strong>GET</strong> /chatrooms</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Chatrooms</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Chatrooms</p>
         <h3 id="possible-parameters-15">Possible parameters</h3>
 
         <table>
@@ -969,20 +903,20 @@
         </table><h3 id="examples-16">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms">http://example.org:9090/plugins/restapi/v1/chatrooms</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms?type=all">http://example.org:9090/plugins/restapi/v1/chatrooms?type=all</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms?type=all&amp;servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms?type=all&amp;servicename=privateconf</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms?search=test">http://example.org:9090/plugins/restapi/v1/chatrooms?search=test</a></p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms">http://example.org:9090/plugins/restapi/v1/chatrooms</a><br>
+                    <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms?type=all">http://example.org:9090/plugins/restapi/v1/chatrooms?type=all</a><br>
+                    <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms?type=all&amp;servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms?type=all&amp;servicename=privateconf</a><br>
+                    <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms?search=test">http://example.org:9090/plugins/restapi/v1/chatrooms?search=test</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="retrieve-a-chat-room">Retrieve a chat room</h2>
         <p>Endpoint to get information over specific chat room</p>
         <blockquote>
             <p><strong>GET</strong> /chatrooms<span>/{roomName}</span></p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Chatroom</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Chatroom</p>
         <h3 id="possible-parameters-16">Possible parameters</h3>
 
         <table>
@@ -1011,18 +945,17 @@
         </table><h3 id="examples-17">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/test">http://example.org:9090/plugins/restapi/v1/chatrooms/test</a><br>
+                    <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/test?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/test?servicename=privateconf</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/test">http://example.org:9090/plugins/restapi/v1/chatrooms/test</a><br>
-                <strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/test?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/test?servicename=privateconf</a></p>
-        </blockquote>
-        <h2 id="retrieve-chat-room-participants">Retrieve chat room participants</h2>
-        <p>Endpoint to get all participants with a role of specified room.</p>
+        <h2 id="retrieve-chat-room-participants-endpoint-to-get-all-participants-with-a-role-of-specified-room.">Retrieve chat room participants Endpoint to get all participants with a role of specified room.</h2>
         <blockquote>
             <p><strong>GET</strong> /chatrooms/{roomName}/participants</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Participants</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Participants</p>
         <h3 id="possible-parameters-17">Possible parameters</h3>
 
         <table>
@@ -1051,17 +984,17 @@
         </table><h3 id="examples-18">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/room1/participants">http://example.org:9090/plugins/restapi/v1/chatrooms/room1/participants</a></p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/room1/participants">http://example.org:9090/plugins/restapi/v1/chatrooms/room1/participants</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="retrieve-chat-room-occupants">Retrieve chat room occupants</h2>
         <p>Endpoint to get all occupants (all roles / affiliations) of a specified room.</p>
         <blockquote>
             <p><strong>GET</strong> /chatrooms/{roomName}/occupants</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Occupants</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Occupants</p>
         <h3 id="possible-parameters-18">Possible parameters</h3>
 
         <table>
@@ -1090,17 +1023,17 @@
         </table><h3 id="examples-19">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/room1/occupants">http://example.org:9090/plugins/restapi/v1/chatrooms/room1/occupants</a></p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/room1/occupants">http://example.org:9090/plugins/restapi/v1/chatrooms/room1/occupants</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="retrieve-chat-room-message-history">Retrieve chat room message history</h2>
         <p>Endpoint to get the chat message history of a specified room.</p>
         <blockquote>
             <p><strong>GET</strong> /chatrooms/{roomName}/chathistory</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Chat History</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Chat History</p>
         <h3 id="possible-parameters-19">Possible parameters</h3>
 
         <table>
@@ -1126,13 +1059,12 @@
                 <td>conference</td>
             </tr>
             </tbody>
-        </table><h2 id="create-a-chat-room">Create a chat room</h2>
-        <p>Endpoint to create a new chat room.</p>
+        </table><h2 id="create-a-chat-room-endpoint-to-create-a-new-chat-room.">Create a chat room Endpoint to create a new chat room.</h2>
         <blockquote>
             <p><strong>POST</strong> /chatrooms</p>
         </blockquote>
-        <p><strong>Payload:</strong> Chatroom<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> Chatroom</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-20">Possible parameters</h3>
 
         <table>
@@ -1154,172 +1086,48 @@
             </tbody>
         </table><h3 id="xml-examples-1">XML Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms">http://example.org:9090/plugins/restapi/v1/chatrooms</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms">http://example.org:9090/plugins/restapi/v1/chatrooms</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload Example 1 (required parameters):</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>naturalName</span><span class="token punctuation">&gt;</span></span>global-1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>naturalName</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>roomName</span><span class="token punctuation">&gt;</span></span>global<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>roomName</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Global Chat Room<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>naturalName</span><span class="token punctuation">&gt;</span></span>global-1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>naturalName</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>roomName</span><span class="token punctuation">&gt;</span></span>global<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>roomName</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Global Chat Room<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <p><strong>Payload Example 2 (available parameters):</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>roomName</span><span class="token punctuation">&gt;</span></span>global<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>roomName</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>naturalName</span><span class="token punctuation">&gt;</span></span>global-2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>naturalName</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Global Chat Room<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subject</span><span class="token punctuation">&gt;</span></span>global-2 Subject<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subject</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>creationDate</span><span class="token punctuation">&gt;</span></span>2014-02-12T15:52:37.592+01:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>creationDate</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>modificationDate</span><span class="token punctuation">&gt;</span></span>2014-09-12T15:35:54.702+02:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>modificationDate</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>maxUsers</span><span class="token punctuation">&gt;</span></span>0<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>maxUsers</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>persistent</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>persistent</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>publicRoom</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>publicRoom</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>logEnabled</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>logEnabled</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>membersOnly</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>membersOnly</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>moderated</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>moderated</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRoles</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>moderator<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>participant<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>visitor<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRoles</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owners</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owner</span><span class="token punctuation">&gt;</span></span>owner@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owner</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owners</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admins</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admin</span><span class="token punctuation">&gt;</span></span>admin@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admin</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admins</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcasts</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcast</span><span class="token punctuation">&gt;</span></span>outcast1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcast</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcasts</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>roomName</span><span class="token punctuation">&gt;</span></span>global<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>roomName</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>naturalName</span><span class="token punctuation">&gt;</span></span>global-2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>naturalName</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Global Chat Room<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subject</span><span class="token punctuation">&gt;</span></span>global-2 Subject<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subject</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>creationDate</span><span class="token punctuation">&gt;</span></span>2014-02-12T15:52:37.592+01:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>creationDate</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>modificationDate</span><span class="token punctuation">&gt;</span></span>2014-09-12T15:35:54.702+02:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>modificationDate</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>maxUsers</span><span class="token punctuation">&gt;</span></span>0<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>maxUsers</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>persistent</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>persistent</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>publicRoom</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>publicRoom</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>logEnabled</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>logEnabled</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>membersOnly</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>membersOnly</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>moderated</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>moderated</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRoles</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>moderator<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>participant<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span>visitor<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRole</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>broadcastPresenceRoles</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owners</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owner</span><span class="token punctuation">&gt;</span></span>owner@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owner</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owners</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admins</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admin</span><span class="token punctuation">&gt;</span></span>admin@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admin</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admins</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcasts</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcast</span><span class="token punctuation">&gt;</span></span>outcast1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcast</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcasts</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h3 id="json-examples-1">JSON Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/json</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms">http://example.org:9090/plugins/restapi/v1/chatrooms</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/json<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms">http://example.org:9090/plugins/restapi/v1/chatrooms</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload Example 1 (required parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-	<span class="token string">"roomName"</span><span class="token punctuation">:</span> <span class="token string">"global"</span><span class="token punctuation">,</span>
-	<span class="token string">"naturalName"</span><span class="token punctuation">:</span> <span class="token string">"global-2"</span><span class="token punctuation">,</span>
-	<span class="token string">"description"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room"</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"roomName"</span><span class="token punctuation">:</span> <span class="token string">"global"</span><span class="token punctuation">,</span> <span class="token string">"naturalName"</span><span class="token punctuation">:</span> <span class="token string">"global-2"</span><span class="token punctuation">,</span> <span class="token string">"description"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room"</span><span class="token punctuation">}</span>
 </code></pre>
         <p><strong>Payload Example 2 (available parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"roomName"</span><span class="token punctuation">:</span> <span class="token string">"global-1"</span><span class="token punctuation">,</span>
-    <span class="token string">"naturalName"</span><span class="token punctuation">:</span> <span class="token string">"global-1_test_hello"</span><span class="token punctuation">,</span>
-    <span class="token string">"description"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room"</span><span class="token punctuation">,</span>
-    <span class="token string">"subject"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room subject"</span><span class="token punctuation">,</span>
-    <span class="token string">"creationDate"</span><span class="token punctuation">:</span> <span class="token string">"2012-10-18T16:55:12.803+02:00"</span><span class="token punctuation">,</span>
-    <span class="token string">"modificationDate"</span><span class="token punctuation">:</span> <span class="token string">"2014-07-10T09:49:12.411+02:00"</span><span class="token punctuation">,</span>
-    <span class="token string">"maxUsers"</span><span class="token punctuation">:</span> <span class="token string">"0"</span><span class="token punctuation">,</span>
-    <span class="token string">"persistent"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"publicRoom"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"registrationEnabled"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"canAnyoneDiscoverJID"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"canOccupantsChangeSubject"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"canOccupantsInvite"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"canChangeNickname"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"logEnabled"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"loginRestrictedToNickname"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"membersOnly"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"moderated"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"broadcastPresenceRoles"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"broadcastPresenceRole"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-            <span class="token string">"moderator"</span><span class="token punctuation">,</span>
-            <span class="token string">"participant"</span><span class="token punctuation">,</span>
-            <span class="token string">"visitor"</span>
-        <span class="token punctuation">]</span>
-    <span class="token punctuation">}</span><span class="token punctuation">,</span>
-    <span class="token string">"owners"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"owner"</span><span class="token punctuation">:</span> <span class="token string">"owner@localhost"</span>
-    <span class="token punctuation">}</span><span class="token punctuation">,</span>
-    <span class="token string">"admins"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"admin"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-            <span class="token string">"admin@localhost"</span><span class="token punctuation">,</span>
-            <span class="token string">"admin2@localhost"</span>
-        <span class="token punctuation">]</span>
-    <span class="token punctuation">}</span><span class="token punctuation">,</span>
-    <span class="token string">"members"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"member"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-            <span class="token string">"member@localhost"</span><span class="token punctuation">,</span>
-            <span class="token string">"member2@localhost"</span>
-        <span class="token punctuation">]</span>
-    <span class="token punctuation">}</span><span class="token punctuation">,</span>
-    <span class="token string">"outcasts"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span>
-        <span class="token string">"outcast"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-            <span class="token string">"outcast@localhost"</span><span class="token punctuation">,</span>
-            <span class="token string">"outcast2@localhost"</span>
-        <span class="token punctuation">]</span>
-    <span class="token punctuation">}</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"roomName"</span><span class="token punctuation">:</span> <span class="token string">"global-1"</span><span class="token punctuation">,</span> <span class="token string">"naturalName"</span><span class="token punctuation">:</span> <span class="token string">"global-1_test_hello"</span><span class="token punctuation">,</span> <span class="token string">"description"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room"</span><span class="token punctuation">,</span> <span class="token string">"subject"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room subject"</span><span class="token punctuation">,</span> <span class="token string">"creationDate"</span><span class="token punctuation">:</span> <span class="token string">"2012-10-18T16:55:12.803+02:00"</span><span class="token punctuation">,</span> <span class="token string">"modificationDate"</span><span class="token punctuation">:</span> <span class="token string">"2014-07-10T09:49:12.411+02:00"</span><span class="token punctuation">,</span> <span class="token string">"maxUsers"</span><span class="token punctuation">:</span> <span class="token string">"0"</span><span class="token punctuation">,</span> <span class="token string">"persistent"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"publicRoom"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"registrationEnabled"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"canAnyoneDiscoverJID"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"canOccupantsChangeSubject"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"canOccupantsInvite"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"canChangeNickname"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"logEnabled"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"loginRestrictedToNickname"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"membersOnly"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"moderated"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"broadcastPresenceRoles"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"broadcastPresenceRole"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"moderator"</span><span class="token punctuation">,</span> <span class="token string">"participant"</span><span class="token punctuation">,</span> <span class="token string">"visitor"</span> <span class="token punctuation">]</span> <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token string">"owners"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"owner"</span><span class="token punctuation">:</span> <span class="token string">"owner@localhost"</span> <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token string">"admins"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"admin"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"admin@localhost"</span><span class="token punctuation">,</span> <span class="token string">"admin2@localhost"</span> <span class="token punctuation">]</span> <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token string">"members"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"member"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"member@localhost"</span><span class="token punctuation">,</span> <span class="token string">"member2@localhost"</span> <span class="token punctuation">]</span> <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token string">"outcasts"</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token string">"outcast"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"outcast@localhost"</span><span class="token punctuation">,</span> <span class="token string">"outcast2@localhost"</span> <span class="token punctuation">]</span> <span class="token punctuation">}</span><span class="token punctuation">}</span>
 </code></pre>
         <p><strong>REST API Version 1.3.0 and later - Payload Example 2 (available parameters):</strong></p>
         <pre class=" language-json"><code class="prism  language-json"><span class="token punctuation">{</span>
-    <span class="token string">"roomName"</span><span class="token punctuation">:</span> <span class="token string">"global-1"</span><span class="token punctuation">,</span>
-    <span class="token string">"naturalName"</span><span class="token punctuation">:</span> <span class="token string">"global-1_test_hello"</span><span class="token punctuation">,</span>
-    <span class="token string">"description"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room"</span><span class="token punctuation">,</span>
-    <span class="token string">"subject"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room subject"</span><span class="token punctuation">,</span>
-    <span class="token string">"creationDate"</span><span class="token punctuation">:</span> <span class="token string">"2012-10-18T16:55:12.803+02:00"</span><span class="token punctuation">,</span>
-    <span class="token string">"modificationDate"</span><span class="token punctuation">:</span> <span class="token string">"2014-07-10T09:49:12.411+02:00"</span><span class="token punctuation">,</span>
-    <span class="token string">"maxUsers"</span><span class="token punctuation">:</span> <span class="token string">"0"</span><span class="token punctuation">,</span>
-    <span class="token string">"persistent"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"publicRoom"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"registrationEnabled"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"canAnyoneDiscoverJID"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"canOccupantsChangeSubject"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"canOccupantsInvite"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"canChangeNickname"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"logEnabled"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"loginRestrictedToNickname"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span>
-    <span class="token string">"membersOnly"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"moderated"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span>
-    <span class="token string">"broadcastPresenceRoles"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-        <span class="token string">"moderator"</span><span class="token punctuation">,</span>
-        <span class="token string">"participant"</span><span class="token punctuation">,</span>
-        <span class="token string">"visitor"</span>
-    <span class="token punctuation">]</span><span class="token punctuation">,</span>
-    <span class="token string">"owners"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-       <span class="token string">"owner@localhost"</span>
-    <span class="token punctuation">]</span><span class="token punctuation">,</span>
-    <span class="token string">"admins"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-       <span class="token string">"admin@localhost"</span>
-    <span class="token punctuation">]</span><span class="token punctuation">,</span>
-    <span class="token string">"members"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-        <span class="token string">"member@localhost"</span>
-    <span class="token punctuation">]</span><span class="token punctuation">,</span>
-    <span class="token string">"outcasts"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>
-        <span class="token string">"outcast@localhost"</span>
-    <span class="token punctuation">]</span>
-<span class="token punctuation">}</span>
+ <span class="token string">"roomName"</span><span class="token punctuation">:</span> <span class="token string">"global-1"</span><span class="token punctuation">,</span> <span class="token string">"naturalName"</span><span class="token punctuation">:</span> <span class="token string">"global-1_test_hello"</span><span class="token punctuation">,</span> <span class="token string">"description"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room"</span><span class="token punctuation">,</span> <span class="token string">"subject"</span><span class="token punctuation">:</span> <span class="token string">"Global chat room subject"</span><span class="token punctuation">,</span> <span class="token string">"creationDate"</span><span class="token punctuation">:</span> <span class="token string">"2012-10-18T16:55:12.803+02:00"</span><span class="token punctuation">,</span> <span class="token string">"modificationDate"</span><span class="token punctuation">:</span> <span class="token string">"2014-07-10T09:49:12.411+02:00"</span><span class="token punctuation">,</span> <span class="token string">"maxUsers"</span><span class="token punctuation">:</span> <span class="token string">"0"</span><span class="token punctuation">,</span> <span class="token string">"persistent"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"publicRoom"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"registrationEnabled"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"canAnyoneDiscoverJID"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"canOccupantsChangeSubject"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"canOccupantsInvite"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"canChangeNickname"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"logEnabled"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"loginRestrictedToNickname"</span><span class="token punctuation">:</span> <span class="token string">"true"</span><span class="token punctuation">,</span> <span class="token string">"membersOnly"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"moderated"</span><span class="token punctuation">:</span> <span class="token string">"false"</span><span class="token punctuation">,</span> <span class="token string">"broadcastPresenceRoles"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"moderator"</span><span class="token punctuation">,</span> <span class="token string">"participant"</span><span class="token punctuation">,</span> <span class="token string">"visitor"</span> <span class="token punctuation">]</span><span class="token punctuation">,</span> <span class="token string">"owners"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"owner@localhost"</span> <span class="token punctuation">]</span><span class="token punctuation">,</span> <span class="token string">"admins"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"admin@localhost"</span> <span class="token punctuation">]</span><span class="token punctuation">,</span> <span class="token string">"members"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"member@localhost"</span> <span class="token punctuation">]</span><span class="token punctuation">,</span> <span class="token string">"outcasts"</span><span class="token punctuation">:</span> <span class="token punctuation">[</span> <span class="token string">"outcast@localhost"</span> <span class="token punctuation">]</span><span class="token punctuation">}</span>
 </code></pre>
-        <h2 id="delete-a-chat-room">Delete a chat room</h2>
-        <p>Endpoint to delete a chat room.</p>
+        <h2 id="delete-a-chat-room-endpoint-to-delete-a-chat-room.">Delete a chat room Endpoint to delete a chat room.</h2>
         <blockquote>
             <p><strong>DELETE</strong> /chatrooms/{roomName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-21">Possible parameters</h3>
 
         <table>
@@ -1348,18 +1156,17 @@
         </table><h3 id="examples-20">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/testroom">http://example.org:9090/plugins/restapi/v1/chatrooms/testroom</a><br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/testroom?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/testroom?servicename=privateconf</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/testroom">http://example.org:9090/plugins/restapi/v1/chatrooms/testroom</a><br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/testroom?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/testroom?servicename=privateconf</a></p>
-        </blockquote>
-        <h2 id="update-a-chat-room">Update a chat room</h2>
-        <p>Endpoint to update a chat room.</p>
+        <h2 id="update-a-chat-room-endpoint-to-update-a-chat-room.">Update a chat room Endpoint to update a chat room.</h2>
         <blockquote>
             <p><strong>PUT</strong> /chatrooms/{roomName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> Chatroom<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> Chatroom</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-22">Possible parameters</h3>
 
         <table>
@@ -1387,62 +1194,30 @@
             </tbody>
         </table><h3 id="examples-21">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global">http://example.org:9090/plugins/restapi/v1/chatrooms/global</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global">http://example.org:9090/plugins/restapi/v1/chatrooms/global</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>roomName</span><span class="token punctuation">&gt;</span></span>global<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>roomName</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>naturalName</span><span class="token punctuation">&gt;</span></span>global-2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>naturalName</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Global Chat Room edit<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subject</span><span class="token punctuation">&gt;</span></span>New subject<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subject</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>password</span><span class="token punctuation">&gt;</span></span>test<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>password</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>creationDate</span><span class="token punctuation">&gt;</span></span>2014-02-12T15:52:37.592+01:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>creationDate</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>modificationDate</span><span class="token punctuation">&gt;</span></span>2014-09-12T14:20:56.286+02:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>modificationDate</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>maxUsers</span><span class="token punctuation">&gt;</span></span>0<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>maxUsers</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>persistent</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>persistent</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>publicRoom</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>publicRoom</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>logEnabled</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>logEnabled</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>membersOnly</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>membersOnly</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>moderated</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>moderated</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRoles</span><span class="token punctuation">/&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owners</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owner</span><span class="token punctuation">&gt;</span></span>owner@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owner</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owners</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admins</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admin</span><span class="token punctuation">&gt;</span></span>admin@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admin</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admins</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcasts</span><span class="token punctuation">&gt;</span></span>
-        <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcast</span><span class="token punctuation">&gt;</span></span>outcast1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcast</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcasts</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>roomName</span><span class="token punctuation">&gt;</span></span>global<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>roomName</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>naturalName</span><span class="token punctuation">&gt;</span></span>global-2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>naturalName</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Global Chat Room edit<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>subject</span><span class="token punctuation">&gt;</span></span>New subject<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>subject</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>password</span><span class="token punctuation">&gt;</span></span>test<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>password</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>creationDate</span><span class="token punctuation">&gt;</span></span>2014-02-12T15:52:37.592+01:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>creationDate</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>modificationDate</span><span class="token punctuation">&gt;</span></span>2014-09-12T14:20:56.286+02:00<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>modificationDate</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>maxUsers</span><span class="token punctuation">&gt;</span></span>0<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>maxUsers</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>persistent</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>persistent</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>publicRoom</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>publicRoom</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>registrationEnabled</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canAnyoneDiscoverJID</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsChangeSubject</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canOccupantsInvite</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>canChangeNickname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>logEnabled</span><span class="token punctuation">&gt;</span></span>true<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>logEnabled</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>loginRestrictedToNickname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>membersOnly</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>membersOnly</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>moderated</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>moderated</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>broadcastPresenceRoles</span><span class="token punctuation">/&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owners</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>owner</span><span class="token punctuation">&gt;</span></span>owner@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owner</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>owners</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admins</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>admin</span><span class="token punctuation">&gt;</span></span>admin@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admin</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>admins</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcasts</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>outcast</span><span class="token punctuation">&gt;</span></span>outcast1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcast</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>outcasts</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>chatRoom</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h2 id="invite-user-to-a-chat-room">Invite user to a chat Room</h2>
         <p>Endpoint to invite a user to a room.</p>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/xml<br>
-                <strong>POST</strong> <a href="http://localhost:9090/plugins/restapi/v1/chatrooms/%7BroomName%7D/invite/%7Bname%7D">http://localhost:9090/plugins/restapi/v1/chatrooms/{roomName}/invite/{name}</a><br>
-                <strong>Payload Example:</strong></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/xml<br>
+                    <strong>POST</strong> <a href="http://localhost:9090/plugins/restapi/v1/chatrooms/%7BroomName%7D/invite/%7Bname%7D">http://localhost:9090/plugins/restapi/v1/chatrooms/{roomName}/invite/{name}</a></p>
+            </blockquote>
         </blockquote>
+        <p><strong>Payload Example:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>mucInvitation</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>reason</span><span class="token punctuation">&gt;</span></span>Hello, come to this room, it is nice<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>reason</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>mucInvitation</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>reason</span><span class="token punctuation">&gt;</span></span>Hello, come to this room, it is nice<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>reason</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>mucInvitation</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-23">Possible parameters</h3>
@@ -1475,8 +1250,8 @@
         <blockquote>
             <p><strong>POST</strong> /chatrooms/{roomName}/{roles}/{name}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-24">Possible parameters</h3>
 
         <table>
@@ -1516,24 +1291,24 @@
             </tbody>
         </table><h3 id="examples-22">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="add-group-with-role-to-chat-room">Add group with role to chat room</h2>
         <p>Endpoint to add a new group with role to a room.</p>
         <blockquote>
             <p><strong>POST</strong> /chatrooms/{roomName}/{roles}/group/{name}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="possible-parameters-25">Possible parameters</h3>
 
         <table>
@@ -1573,21 +1348,24 @@
             </tbody>
         </table><h3 id="examples-23">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml</p>
+            </blockquote>
+            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testGroup</a></p>
+            <blockquote>
+                <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/group/testGroup</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/group/testGroup</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/group/testGroup</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testUser?servicename=privateconf</a></p>
+            </blockquote>
         </blockquote>
+        <h2 id="delete-a-user-from-a-chat-room-endpoint-to-remove-a-room-user-role.">Delete a user from a chat room Endpoint to remove a room user role.</h2>
         <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testGroup</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/group/testGroup</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/group/testGroup</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/group/testGroup</a><br>
-                <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testUser?servicename=privateconf</a></p>
+            <p><strong>DELETE</strong> /chatrooms/{roomName}/{roles}/{name}</p>
         </blockquote>
-        <h2 id="delete-a-user-from-a-chat-room">Delete a user from a chat room</h2>
-        <p>Endpoint to remove a room user role.<br>
-            DELETE /chatrooms/{roomName}/{roles}/{name}</p>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-26">Possible parameters</h3>
 
         <table>
@@ -1627,39 +1405,37 @@
             </tbody>
         </table><h3 id="examples-24">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser</a><br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com</a><br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser</a><br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser</a><br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser</a><br>
-                <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser</a><br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com</a><br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser</a><br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser</a><br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser</a><br>
+                    <strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf</a></p>
+            </blockquote>
         </blockquote>
         <h1 id="system-related-rest-endpoints">System related REST Endpoints</h1>
-        <h2 id="retrieve-all-system-properties">Retrieve all system properties</h2>
-        <p>Endpoint to get all system properties</p>
+        <h2 id="retrieve-all-system-properties-endpoint-to-get-all-system-properties">Retrieve all system properties Endpoint to get all system properties</h2>
         <blockquote>
             <p><strong>GET</strong> /system/properties</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> System properties</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> System properties</p>
         <h3 id="examples-25">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties">http://example.org:9090/plugins/restapi/v1/system/properties</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties">http://example.org:9090/plugins/restapi/v1/system/properties</a></p>
-        </blockquote>
-        <h2 id="retrieve-system-property">Retrieve system property</h2>
-        <p>Endpoint to get information over specific system property</p>
+        <h2 id="retrieve-system-property-endpoint-to-get-information-over-specific-system-property">Retrieve system property Endpoint to get information over specific system property</h2>
         <blockquote>
             <p><strong>GET</strong> /system/properties/{propertyName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> System property</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> System property</p>
         <h3 id="possible-parameters-27">Possible parameters</h3>
 
         <table>
@@ -1680,22 +1456,23 @@
             </tr>
             </tbody>
         </table><h3 id="examples-26">Examples</h3>
-        <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain">http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain</a></p>
-        <h2 id="create-a-system-property">Create a system property</h2>
-        <p>Endpoint to create a system property</p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain">http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain</a></p>
+        </blockquote>
+        <h2 id="create-a-system-property-endpoint-to-create-a-system-property">Create a system property Endpoint to create a system property</h2>
         <blockquote>
             <p><strong>POST</strong> system/properties</p>
         </blockquote>
-        <p><strong>Payload:</strong> System Property<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> System Property</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="examples-27">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties">http://example.org:9090/plugins/restapi/v1/system/properties</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties">http://example.org:9090/plugins/restapi/v1/system/properties</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload Example:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
@@ -1706,8 +1483,8 @@
         <blockquote>
             <p><strong>DELETE</strong> /system/properties/{propertyName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-28">Possible parameters</h3>
 
         <table>
@@ -1730,17 +1507,17 @@
         </table><h3 id="examples-28">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="update-a-system-property">Update a system property</h2>
         <p>Endpoint to update / overwrite a system property</p>
         <blockquote>
             <p><strong>PUT</strong> /system/properties/{propertyName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> System property<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> System property</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-29">Possible parameters</h3>
 
         <table>
@@ -1762,11 +1539,11 @@
             </tbody>
         </table><h3 id="examples-29">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
@@ -1777,34 +1554,115 @@
         <blockquote>
             <p><strong>GET</strong> /system/statistics/sessions</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Sessions count</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Sessions count</p>
         <h3 id="examples-30">Examples</h3>
-        <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/statistics/sessions">http://example.org:9090/plugins/restapi/v1/system/statistics/sessions</a></p>
-        <h1 id="group-related-rest-endpoints">Group related REST Endpoints</h1>
-        <h2 id="retrieve-all-groups">Retrieve all groups</h2>
-        <p>Endpoint to get all groups</p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/statistics/sessions">http://example.org:9090/plugins/restapi/v1/system/statistics/sessions</a></p>
+        </blockquote>
+        <h2 id="check-the-liveness-state-using-all-checks">Check the ‘liveness’ state (using all checks)</h2>
+        <p>Detects if Openfire has reached a state that it cannot recover from, except for with a restart, based on every liveness check that it has implemented.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/liveness</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="perform-deadlock-liveness-check">Perform ‘deadlock’ liveness check</h2>
+        <p>Detects if Openfire has reached a state that it cannot recover from because of a deadlock.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/liveness/deadlock</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="perform-properties-liveness-check">Perform ‘properties’ liveness check</h2>
+        <p>Detects if Openfire has reached a state that it cannot recover from because a system property change requires a restart to take effect.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/liveness/properties</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="check-the-readiness-state-using-all-checks">Check the ‘readiness’ state (using all checks)</h2>
+        <p>Detects if Openfire is in a state where it is ready to process traffic, based on every readiness check that it has implemented.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/readiness</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="perform-server-readiness-check">Perform ‘server’ readiness check</h2>
+        <p>Detects if Openfire’s core service has been started.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/readiness/server</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="perform-cluster-readiness-check">Perform ‘cluster’ readiness check</h2>
+        <p>Detects if the cluster functionality has finished starting (or is disabled).</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/readiness/cluster</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="perform-plugins-readiness-check">Perform ‘plugins’ readiness check</h2>
+        <p>Detects if Openfire has finished starting its plugins.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/readiness/plugins</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h2 id="perform-connections-readiness-check">Perform ‘connections’ readiness check</h2>
+        <p>Detects if Openfire is ready to accept connection requests.</p>
+        <blockquote>
+            <p><strong>GET</strong> /system/readiness/connections</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
+        <h3 id="possible-parameters-30">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>connectionType</td>
+                <td>@Path</td>
+                <td>Optional. Use to limit the check to one particular connection type. One of: SOCKET_S2S, SOCKET_C2S, BOSH_C2S, WEBADMIN, COMPONENT, CONNECTION_MANAGER</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>encypted</td>
+                <td>@Path</td>
+                <td>Check the encrypted (true) or unencrypted (false) variant of the connection type. Only used in combination with ‘connectionType’, as without it, all types and both encrypted and unencrypted are checked.</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table><h1 id="group-related-rest-endpoints">Group related REST Endpoints</h1>
+        <h2 id="retrieve-all-groups-endpoint-to-get-all-groups">Retrieve all groups Endpoint to get all groups</h2>
         <blockquote>
             <p><strong>GET</strong> /groups</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Groups</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Groups</p>
         <h3 id="examples-31">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups">http://example.org:9090/plugins/restapi/v1/groups</a></p>
+            </blockquote>
         </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups">http://example.org:9090/plugins/restapi/v1/groups</a></p>
-        </blockquote>
-        <h2 id="retrieve-a-group">Retrieve a group</h2>
-        <p>Endpoint to get information over specific group</p>
+        <h2 id="retrieve-a-group-endpoint-to-get-information-over-specific-group">Retrieve a group Endpoint to get information over specific group</h2>
         <blockquote>
             <p><strong>GET</strong> /groups/{groupName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Group</p>
-        <h3 id="possible-parameters-30">Possible parameters</h3>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Group</p>
+        <h3 id="possible-parameters-31">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1824,39 +1682,37 @@
             </tr>
             </tbody>
         </table><h3 id="examples-32">Examples</h3>
-        <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/moderators">http://example.org:9090/plugins/restapi/v1/groups/moderators</a></p>
-        <h2 id="create-a-group">Create a group</h2>
-        <p>Endpoint to create a new group</p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/moderators">http://example.org:9090/plugins/restapi/v1/groups/moderators</a></p>
+        </blockquote>
+        <h2 id="create-a-group-endpoint-to-create-a-new-group">Create a group Endpoint to create a new group</h2>
         <blockquote>
             <p><strong>POST</strong> /groups</p>
         </blockquote>
-        <p><strong>Payload:</strong> Group<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> Group</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="examples-33">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type: application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups">http://example.org:9090/plugins/restapi/v1/groups</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups">http://example.org:9090/plugins/restapi/v1/groups</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload Example:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>GroupName<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Some description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>shared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>shared</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>GroupName<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Some description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>isshared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>isshared</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h2 id="delete-a-group">Delete a group</h2>
         <p>Endpoint to delete a group</p>
         <blockquote>
             <p><strong>DELETE</strong> /groups/{groupName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-31">Possible parameters</h3>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-32">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1878,18 +1734,18 @@
         </table><h3 id="examples-34">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupToDelete">http://example.org:9090/plugins/restapi/v1/groups/groupToDelete</a></p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupToDelete">http://example.org:9090/plugins/restapi/v1/groups/groupToDelete</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="update-a-group">Update a group</h2>
         <p>Endpoint to update / overwrite a group</p>
         <blockquote>
             <p><strong>PUT</strong> /groups/{groupName}</p>
         </blockquote>
-        <p><strong>Payload:</strong> Group<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-32">Possible parameters</h3>
+        <p><strong>Payload:</strong> Group</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-33">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1910,19 +1766,16 @@
             </tbody>
         </table><h3 id="examples-35">Examples</h3>
         <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=<br>
-                <strong>Header:</strong> Content-Type application/xml</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupNameToUpdate">http://example.org:9090/plugins/restapi/v1/groups/groupNameToUpdate</a></p>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupNameToUpdate">http://example.org:9090/plugins/restapi/v1/groups/groupNameToUpdate</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>groupNameToUpdate<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>New description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>shared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>shared</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>groupNameToUpdate<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>New description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>isshared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>isshared</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h1 id="session-related-rest-endpoints">Session related REST Endpoints</h1>
         <h2 id="retrieve-all-user-session">Retrieve all user session</h2>
@@ -1930,51 +1783,22 @@
         <blockquote>
             <p><strong>GET</strong> /sessions</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Sessions</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Sessions</p>
         <h3 id="examples-36">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions">http://example.org:9090/plugins/restapi/v1/sessions</a></p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions">http://example.org:9090/plugins/restapi/v1/sessions</a></p>
+            </blockquote>
         </blockquote>
         <h2 id="retrieve-the-user-sessions">Retrieve the user sessions</h2>
         <p>Endpoint to get sessions from a user</p>
         <blockquote>
             <p><strong>GET</strong> /sessions/{username}</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Sessions</p>
-        <h3 id="possible-parameters-33">Possible parameters</h3>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Parameter Type</th>
-                <th>Description</th>
-                <th>Default value</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>username</td>
-                <td>@Path</td>
-                <td>The username of the user</td>
-                <td></td>
-            </tr>
-            </tbody>
-        </table><h3 id="examples-37">Examples</h3>
-        <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions/testuser">http://example.org:9090/plugins/restapi/v1/sessions/testuser</a></p>
-        <h2 id="close-all-user-sessions">Close all user sessions</h2>
-        <p>Endpoint to close/kick sessions from a user</p>
-        <blockquote>
-            <p><strong>DELETE</strong> /sessions/{username}</p>
-        </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Sessions</p>
         <h3 id="possible-parameters-34">Possible parameters</h3>
 
         <table>
@@ -1994,29 +1818,61 @@
                 <td></td>
             </tr>
             </tbody>
+        </table><h3 id="examples-37">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions/testuser">http://example.org:9090/plugins/restapi/v1/sessions/testuser</a></p>
+        </blockquote>
+        <h2 id="close-all-user-sessions">Close all user sessions</h2>
+        <p>Endpoint to close/kick sessions from a user</p>
+        <blockquote>
+            <p><strong>DELETE</strong> /sessions/{username}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-35">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>username</td>
+                <td>@Path</td>
+                <td>The username of the user</td>
+                <td></td>
+            </tr>
+            </tbody>
         </table><h3 id="examples-38">Examples</h3>
-        <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-        <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions/testuser">http://example.org:9090/plugins/restapi/v1/sessions/testuser</a></p>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions/testuser">http://example.org:9090/plugins/restapi/v1/sessions/testuser</a></p>
+        </blockquote>
         <h1 id="message-related-rest-endpoints">Message related REST Endpoints</h1>
         <h2 id="send-a-broadcast-message">Send a broadcast message</h2>
         <p>Endpoint to send a broadcast/server message to all online users</p>
         <blockquote>
             <p><strong>POST</strong> /messages/users</p>
         </blockquote>
-        <p><strong>Payload:</strong> Message<br>
-            <strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Payload:</strong> Message</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
         <h3 id="examples-39">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
-        </blockquote>
-        <blockquote>
-            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/messages/users">http://example.org:9090/plugins/restapi/v1/messages/users</a></p>
+            <blockquote>
+                <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/messages/users">http://example.org:9090/plugins/restapi/v1/messages/users</a></p>
+            </blockquote>
         </blockquote>
         <p><strong>Payload:</strong></p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>message</span><span class="token punctuation">&gt;</span></span>
-	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>body</span><span class="token punctuation">&gt;</span></span>Your message<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>body</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>message</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>body</span><span class="token punctuation">&gt;</span></span>Your message<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>body</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>message</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <h1 id="security-audit-related-rest-endpoints">Security Audit related REST Endpoints</h1>
         <h2 id="retrieve-the-security-audit-logs">Retrieve the Security audit logs</h2>
@@ -2024,9 +1880,9 @@
         <blockquote>
             <p><strong>GET</strong> /logs/security</p>
         </blockquote>
-        <p><strong>Payload:</strong> none<br>
-            <strong>Return value:</strong> Security Audit Logs</p>
-        <h3 id="possible-parameters-35">Possible parameters</h3>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> Security Audit Logs</p>
+        <h3 id="possible-parameters-36">Possible parameters</h3>
 
         <table>
             <thead>
@@ -2072,16 +1928,114 @@
         </table><h3 id="examples-40">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/logs/security">http://example.org:9090/plugins/restapi/v1/logs/security</a></p>
+            </blockquote>
         </blockquote>
+        <h1 id="clustering-related-rest-endpoints">Clustering related REST Endpoints</h1>
+        <h2 id="retrieve-information-for-all-cluster-nodes.">Retrieve information for all cluster nodes.</h2>
+        <p>Endpoint to get information for all nodes in the cluster. Note that this endpoint can only return data for remote nodes<br>
+            when the instance of Openfire that processes this query has successfully joined the cluster.</p>
         <blockquote>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/logs/security">http://example.org:9090/plugins/restapi/v1/logs/security</a></p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/nodes">http://example.org:9090/plugins/restapi/v1/clustering/nodes</a></p>
         </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> ClusterNodes</p>
+        <h3 id="examples-41">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/nodes">http://example.org:9090/plugins/restapi/v1/clustering/nodes</a></p>
+        </blockquote>
+        <h2 id="retrieve-information-for-a-specific-cluster-node.">Retrieve information for a specific cluster node.</h2>
+        <p>Endpoint to get information for a specific cluster node. Note that this endpoint can only return data for remote nodes<br>
+            when the instance of Openfire that processes this query has successfully joined the cluster.</p>
+        <blockquote>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/nodes/%7BnodeId%7D">http://example.org:9090/plugins/restapi/v1/clustering/nodes/{nodeId}</a></p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> ClusterNode</p>
+        <h3 id="possible-parameters-37">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>nodeId</td>
+                <td>@Path</td>
+                <td>Exact NodeID</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-42">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/nodes/52a89928-66f7-45fd-9bb8-096de07400ac">http://example.org:9090/plugins/restapi/v1/clustering/nodes/52a89928-66f7-45fd-9bb8-096de07400ac</a></p>
+        </blockquote>
+        <h2 id="retrieve-the-clustering-status">Retrieve the Clustering status</h2>
+        <p>Endpoint to get description of clustering status</p>
+        <blockquote>
+            <p><strong>GET</strong> /clustering/status</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> String describing the clustering status of this Openfire instance</p>
+        <h3 id="examples-43">Examples</h3>
+        <blockquote>
+            <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/status">http://example.org:9090/plugins/restapi/v1/clustering/status</a></p>
+        </blockquote>
+        <h3 id="possible-responses">Possible Responses</h3>
+        <ul>
+            <li>SENIOR AND ONLY MEMBER</li>
+            <li>Senior member</li>
+            <li>Junior member</li>
+            <li>Starting up</li>
+            <li>Disabled</li>
+        </ul>
         <h1 id="data-format">Data format</h1>
         <p>Openfire REST API provides XML and JSON as data format. The default data format is XML.<br>
-            To get a JSON result, please add “<strong>Accept application/json</strong>” to the request header.<br>
+            To get a JSON result, please add “<strong>Accept: application/json</strong>” to the request header.<br>
             If you want to create a resource with JSON data format, please add “<strong>Content-Type: application/json</strong>”.</p>
         <h2 id="data-types">Data types</h2>
-        <h3 id="user">User</h3>
+        <h3 id="clusternode">ClusterNode</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Optional</th>
+                <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>hostName</td>
+                <td>No</td>
+                <td>The hostname and IP address of the server on which this cluster node is running.</td>
+            </tr>
+            <tr>
+                <td>nodeID</td>
+                <td>No</td>
+                <td>A unique identifier of this cluster node.</td>
+            </tr>
+            <tr>
+                <td>joinedTime</td>
+                <td>No</td>
+                <td>Timestamp when the node joined the cluster.</td>
+            </tr>
+            <tr>
+                <td>seniorMember</td>
+                <td>No</td>
+                <td>Boolean value indicating if the node is currently the senior member of the cluster.</td>
+            </tr>
+            </tbody>
+        </table><h3 id="user">User</h3>
 
         <table>
             <thead>
@@ -2534,63 +2488,17 @@
         <h2 id="using-the-plugin">Using the Plugin</h2>
         <p>To administer users, submit HTTP requests to the userservice service. The service address is [hostname]plugins/restapi/userservice. For example, if your server name is “<a href="http://example.com">example.com</a>”, the URL is <a href="http://example.com/plugins/restapi/userservice">http://example.com/plugins/restapi/userservice</a></p>
         <p>The following parameters can be passed into the request:</p>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Name</th>
-                <th></th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>type</td>
-                <td>Required</td>
-                <td>The admin service required. Possible values are ‘add’, ‘delete’, ‘update’, ‘enable’, ‘disable’, ‘add_roster’, ‘update_roster’, ‘delete_roster’, ‘grouplist’, ‘usergrouplist’.</td>
-            </tr>
-            <tr>
-                <td>secret</td>
-                <td>Required</td>
-                <td>The secret key that allows access to the User Service.</td>
-            </tr>
-            <tr>
-                <td>username</td>
-                <td>Required</td>
-                <td>The username of the user to ‘add’, ‘delete’, ‘update’, ‘enable’, ‘disable’, ‘add_roster’, ‘update_roster’, ‘delete_roster’. ie the part before the @ symbol.</td>
-            </tr>
-            <tr>
-                <td>password</td>
-                <td>Required for ‘add’ operation</td>
-                <td>The password of the new user or the user being updated.</td>
-            </tr>
-            <tr>
-                <td>name</td>
-                <td>Optional</td>
-                <td>The display name of the new user or the user being updated. For ‘add_roster’, ‘update_roster’ operations specifies the nickname of the roster item.</td>
-            </tr>
-            <tr>
-                <td>email</td>
-                <td>Optional</td>
-                <td>The email address of the new user or the user being updated.</td>
-            </tr>
-            <tr>
-                <td>groups</td>
-                <td>Optional</td>
-                <td>List of groups where the user is a member. Values are comma delimited. When used with types “add” or “update”, it adds the user to shared groups and auto-creates new groups. When used with ‘add_roster’ and ‘update_roster’, it adds the user to roster groups provided the group name does not clash with an existing shared group.</td>
-            </tr>
-            <tr>
-                <td>item_jid</td>
-                <td>Required for ‘add_roster’, ‘update_roster’, ‘delete_roster’ operations.</td>
-                <td>The JID of the roster item</td>
-            </tr>
-            <tr>
-                <td>subscription</td>
-                <td>Optional</td>
-                <td>Type of subscription for ‘add_roster’, ‘update_roster’ operations. Possible numeric values are: -1(remove), 0(none), 1(to), 2(from), 3(both).</td>
-            </tr>
-            </tbody>
-        </table><h2 id="sample-html">Sample HTML</h2>
+        <p>| Name         |                                                                                  | Description                                                                                                                                                                                                                                                                                                                            | |--------------|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|<br>
+            | type         |   Required                                                                  | The admin service required. Possible values are ‘add’, ‘delete’, ‘update’, ‘enable’, ‘disable’, ‘add_roster’, ‘update_roster’, ‘delete_roster’, ‘grouplist’, ‘usergrouplist’.                                                                                                                                                          |<br>
+            | secret       |   Required                                                                  | The secret key that allows access to the User Service.                                                                                                                                                                                                                                                                                 |<br>
+            | username     |   Required                                                                  | The username of the user to ‘add’, ‘delete’, ‘update’, ‘enable’, ‘disable’, ‘add_roster’, ‘update_roster’, ‘delete_roster’. ie the part before the @ symbol.                                                                                                                                                                           |<br>
+            | password     |   Required for ‘add’ operation                                            | The password of the new user or the user being updated.                                                                                                                                                                                                                                                                                |<br>
+            | name         |   Optional                                                                | The display name of the new user or the user being updated. For ‘add_roster’, ‘update_roster’ operations specifies the nickname of the roster item.                                                                                                                                                                                    |<br>
+            | email        |   Optional                                                                | The email address of the new user or the user being updated.                                                                                                                                                                                                                                                                           |<br>
+            | groups       |   Optional                                                                | List of groups where the user is a member. Values are comma delimited. When used with types “add” or “update”, it adds the user to shared groups and auto-creates new groups. When used with ‘add_roster’ and ‘update_roster’, it adds the user to roster groups provided the group name does not clash with an existing shared group. |<br>
+            | item_jid     |   Required for ‘add_roster’, ‘update_roster’, ‘delete_roster’ operations. | The JID of the roster item                                                                                                                                                                                                                                                                                                             |<br>
+            | subscription | Optional                                                                 | Type of subscription for ‘add_roster’, ‘update_roster’ operations. Possible numeric values are: -1(remove), 0(none), 1(to), 2(from), 3(both).                                                                                                                                                                                          |</p>
+        <h2 id="sample-html">Sample HTML</h2>
         <p>The following example adds a user</p>
         <p><a href="http://example.com:9090/plugins/restapi/userservice?type=add&amp;secret=bigsecret&amp;username=kafka&amp;password=drowssap&amp;name=franz&amp;email=franz@kafka.com">http://example.com:9090/plugins/restapi/userservice?type=add&amp;secret=bigsecret&amp;username=kafka&amp;password=drowssap&amp;name=franz&amp;email=franz@kafka.com</a></p>
         <p>The following example adds a user, adds two shared groups (if not existing) and adds the user to both groups.</p>
@@ -2615,22 +2523,20 @@
         <p><a href="http://example.com:9090/plugins/restapi/userservice?type=grouplist&amp;secret=bigsecret">http://example.com:9090/plugins/restapi/userservice?type=grouplist&amp;secret=bigsecret</a><br>
             Which replies an XML group list formatted like this:</p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>result</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>group1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>group2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>result</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>group1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>group2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>result</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
         <p>The following example gets all groups for a specific user</p>
         <p><a href="http://example.com:9090/plugins/restapi/userservice?type=usergrouplist&amp;secret=bigsecret&amp;username=kafka">http://example.com:9090/plugins/restapi/userservice?type=usergrouplist&amp;secret=bigsecret&amp;username=kafka</a><br>
             Which replies an XML group list formatted like this:</p>
         <pre class=" language-xml"><code class="prism  language-xml"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>result</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>usergroup1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>usergroup2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>result</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>usergroup1<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>groupname</span><span class="token punctuation">&gt;</span></span>usergroup2<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>groupname</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>result</span><span class="token punctuation">&gt;</span></span>
 </code></pre>
-        <p>* When sending double characters (Chinese/Japanese/Korean etc) you should URLEncode the string as utf8.<br>
-            In Java this is done like this<br>
-            URLEncoder.encode(username, “UTF-8”));<br>
-            If the strings are encoded incorrectly, double byte characters will look garbeled in the Admin Console.</p>
+        <p>When sending double characters (Chinese/Japanese/Korean etc.) you should URLEncode the string as utf8.<br>
+            In Java this is done like this</p>
+        <blockquote>
+            <p>URLEncoder.encode(username, “UTF-8”));</p>
+        </blockquote>
+        <p>If the strings are encoded incorrectly, double byte characters will look garbeled in the Admin Console.</p>
         <h2 id="server-reply">Server Reply</h2>
         <p>The server will reply to all User Service requests with an XML result page. If the request was processed successfully the return will be a “result” element with a text body of “OK”, or an XML grouplist formatted like in the example for “grouplist” and “usergrouplist” above. If the request was unsuccessful, the return will be an “error” element with a text body of one of the following error strings.</p>
 
@@ -2667,8 +2573,7 @@
                 <td>Roster item can not be added/deleted to/from a shared group for operations with roster.</td>
             </tr>
             </tbody>
-        </table><!--stackedit_data:&#10;eyJoaXN0b3J5IjpbLTExNjM0MzMwNzJdfQ==&#10;-->
-
+        </table>
     </div>
 </div>
 </body>


### PR DESCRIPTION
The HTML version of the readme was seriously lagging behind the Markdown version. This commit brings both back in sync.

To generate the HTML version, I took the Markdown version, which I added to the webapp of https://stackedit.io/

Next, I exported the stackedit-generated page as HTML, using their "Stylized HTML with TOC" template.

I've only changed the HTML title in the generated file.