### PR TITLE
fixes #96: Don't require auth for readiness/liveness endpoints

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.8.1</b> ???</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/96'>#96</a>] - Don't require auth for readiness/liveness endpoints</li>
+</ul>
+
 <p><b>1.8.0</b> April 6, 2022</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/76'>#76</a>] - Add a clustering status endpoint</li>

--- a/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
@@ -62,6 +62,11 @@ public class AuthFilter implements ContainerRequestFilter {
             return;
         }
 
+        if (isStatusEndpoint(containerRequest.getUriInfo().getRequestUri().getPath())) {
+            LOG.debug("Authentication was bypassed for a status endpoint");
+            return;
+        }
+
         if (!plugin.isEnabled()) {
             LOG.debug("REST API Plugin is not enabled");
             throw new WebApplicationException(Status.FORBIDDEN);
@@ -139,5 +144,12 @@ public class AuthFilter implements ContainerRequestFilter {
                 throw new WebApplicationException(Status.UNAUTHORIZED);
             }
         }
+    }
+
+    private boolean isStatusEndpoint(String path){
+        return path.equals("/plugins/restapi/v1/system/liveness") ||
+            path.startsWith("/plugins/restapi/v1/system/liveness/") ||
+            path.equals("/plugins/restapi/v1/system/readiness") ||
+            path.startsWith("/plugins/restapi/v1/system/readiness/");
     }
 }


### PR DESCRIPTION
Fixes #96

Tested via /plugins/restapi/docs/index.html#/System/liveness and the like.