### PR TITLE
fixes #99: Don't hard-code OpenAPI yaml link to localhost

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ REST API Plugin Changelog
 
 <p><b>1.8.1</b> ???</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/99'>#99</a>] - Fix hard-coded link to localhost for OpenAPI yaml link in docs.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/96'>#96</a>] - Don't require auth for readiness/liveness endpoints</li>
 </ul>
 

--- a/src/web/docs/index.html
+++ b/src/web/docs/index.html
@@ -41,7 +41,7 @@
     window.onload = function() {
         // Begin Swagger UI call region
         const ui = SwaggerUIBundle({
-            url: "http://localhost:9090/plugins/restapi/v1/openapi.yaml",
+            url: window.location.origin + "/plugins/restapi/v1/openapi.yaml",
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [


### PR DESCRIPTION
Fixes #99 - the link to the openapi.yml below the title was hardcoded to localhost.

![image](https://user-images.githubusercontent.com/2117083/163878218-10283c64-f8bc-457a-aa91-1a0c511af8c5.png)

becomes

![image](https://user-images.githubusercontent.com/2117083/163878381-57e4966b-9c99-423c-9e11-de37dedc573c.png)

/hattip @ruicaramalho for the report