### PR TITLE
Properly process requests that have invalid MUC service or room references

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -48,6 +48,7 @@ REST API Plugin Changelog
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/99'>#99</a>] - Fix hard-coded link to localhost for OpenAPI yaml link in docs.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/96'>#96</a>] - Don't require auth for readiness/liveness endpoints</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/74'>#74</a>] - Return HTTP status code 404 instead of 500 when passing incorrect MUC service/room name</li>
 </ul>
 
 <p><b>1.8.0</b> April 6, 2022</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2022-04-06</date>
+    <date>2022-05-11</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/src/java/org/jivesoftware/openfire/plugin/rest/exceptions/ExceptionType.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/exceptions/ExceptionType.java
@@ -40,7 +40,9 @@ public final class ExceptionType {
 
     /** The Constant GROUP_NOT_FOUND. */
     public static final String GROUP_NOT_FOUND = "GroupNotFoundException";
-    
+
+    public static final String MUCSERVICE_NOT_FOUND = "MUCServiceNotFoundException";
+
     /** The Constant ROOM_NOT_FOUND. */
     public static final String ROOM_NOT_FOUND = "RoomNotFoundException";
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAdminsService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAdminsService.java
@@ -18,9 +18,12 @@ package org.jivesoftware.openfire.plugin.rest.service;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ErrorResponse;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 
 import javax.ws.rs.*;
@@ -36,7 +39,11 @@ public class MUCRoomAdminsService {
     @Operation( summary = "Add room admin",
         description = "Adds an administrator to a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Administrator added to the room.")
+            @ApiResponse(responseCode = "201", description = "Administrator added to the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room admin, or adding it would cause a conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomAdmin(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -53,7 +60,11 @@ public class MUCRoomAdminsService {
     @Operation( summary = "Add room admins",
         description = "Adds all members of an Openfire user group as administrator to a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Administrators added to the room.")
+            @ApiResponse(responseCode = "201", description = "Administrators added to the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room admin, or adding it would cause a conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomAdminGroup(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -70,7 +81,12 @@ public class MUCRoomAdminsService {
     @Operation( summary = "Remove room admin",
         description = "Removes a user as an administrator of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "Administrator removed from the room.")
+            @ApiResponse(responseCode = "200", description = "Administrator removed from the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Applying this affiliation change would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomAdmin(
             @Parameter(description = "The (bare) JID of the entity that is to be removed as an administrators of the room.", example = "john@example.org", required = true) @PathParam("jid") String jid,
@@ -88,7 +104,12 @@ public class MUCRoomAdminsService {
     @Operation( summary = "Remove room admins",
         description = "Removes all members of an Openfire user group as administrator of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "Administrators removed from the room.")
+            @ApiResponse(responseCode = "200", description = "Administrators removed from the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Applying this affiliation change would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomAdminGroup(
         @Parameter(description = "The name of the user group from which all members will be removed as administrators of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersService.java
@@ -18,9 +18,12 @@ package org.jivesoftware.openfire.plugin.rest.service;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ErrorResponse;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 
 import javax.ws.rs.*;
@@ -36,7 +39,11 @@ public class MUCRoomMembersService {
     @Operation( summary = "Add room member",
         description = "Registers a JID as a member of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Member added to the room.")
+            @ApiResponse(responseCode = "201", description = "Member added to the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room admin, or adding it would cause a conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomMember(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -53,7 +60,11 @@ public class MUCRoomMembersService {
     @Operation( summary = "Add room members",
         description = "Adds all members of an Openfire user group as registered members of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Members added to the room.")
+            @ApiResponse(responseCode = "201", description = "Members added to the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room admin, or adding it would cause a conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomMemberGroup(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -70,7 +81,12 @@ public class MUCRoomMembersService {
     @Operation( summary = "Remove room member",
         description = "Removes a JID as a registered member of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "Member removed from the room.")
+            @ApiResponse(responseCode = "200", description = "Member removed from the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Applying this affiliation change would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomMember(
             @Parameter(description = "The (bare) JID of the entity that is to be removed as a registered member of the room.", example = "john@example.org", required = true) @PathParam("jid") String jid,
@@ -88,7 +104,12 @@ public class MUCRoomMembersService {
     @Operation( summary = "Remove room members",
         description = "Removes all members of an Openfire user group as registered members of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "Member removed from the room.")
+            @ApiResponse(responseCode = "200", description = "Member removed from the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Applying this affiliation change would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomMemberGroup(
             @Parameter(description = "The name of the user group from which all members will be removed as registered members of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOutcastsService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOutcastsService.java
@@ -18,9 +18,12 @@ package org.jivesoftware.openfire.plugin.rest.service;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ErrorResponse;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 
 import javax.ws.rs.*;
@@ -36,7 +39,12 @@ public class MUCRoomOutcastsService {
     @Operation( summary = "Add room outcast",
         description = "Marks a JID as outcast of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "JID marked as outcast.")
+            @ApiResponse(responseCode = "201", description = "JID marked as outcast."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room outcast.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Adding this JID as a room outcast would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomOutcast(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -53,7 +61,12 @@ public class MUCRoomOutcastsService {
     @Operation( summary = "Add room outcasts",
         description = "Marks all members of an Openfire user group as outcasts of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Group members marked as outcast.")
+            @ApiResponse(responseCode = "201", description = "Group members marked as outcast."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room outcast.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Adding this JID as a room outcast would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomOutcastGroup(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -70,7 +83,12 @@ public class MUCRoomOutcastsService {
     @Operation( summary = "Remove room outcast",
         description = "Unmarks a JID as outcast of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "JID no longer marked as outcast.")
+            @ApiResponse(responseCode = "200", description = "JID no longer marked as outcast."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Applying this affiliation change would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomOutcast(
             @Parameter(description = "The (bare) JID of the entity that is to be removed as an outcast of the room.", example = "john@example.org", required = true) @PathParam("jid") String jid,
@@ -88,7 +106,12 @@ public class MUCRoomOutcastsService {
     @Operation( summary = "Remove room outcasts",
         description = "Removes all members of an Openfire user group as outcast of a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "Group members no longer marked as outcast.")
+            @ApiResponse(responseCode = "200", description = "Group members no longer marked as outcast."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Applying this affiliation change would cause a room conflict.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomOutcastGroup(
             @Parameter(description = "The name of the user group from which all members will be removed as outcast of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOwnersService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOwnersService.java
@@ -18,9 +18,12 @@ package org.jivesoftware.openfire.plugin.rest.service;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.exceptions.ErrorResponse;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 
 import javax.ws.rs.*;
@@ -36,7 +39,11 @@ public class MUCRoomOwnersService {
     @Operation( summary = "Add room owner",
         description = "Adds an owner to a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Owner added to the room.")
+            @ApiResponse(responseCode = "201", description = "Owner added to the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room owner.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomOwner(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -53,7 +60,11 @@ public class MUCRoomOwnersService {
     @Operation( summary = "Add room owners",
         description = "Adds all members of an Openfire user group as owners to a multi-user chat room.",
         responses = {
-            @ApiResponse(responseCode = "201", description = "Owners added to the room.")
+            @ApiResponse(responseCode = "201", description = "Owners added to the room."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to add a room owner.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response addMUCRoomOwnerGroup(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
@@ -71,7 +82,11 @@ public class MUCRoomOwnersService {
         description = "Removes a user as an owner of a multi-user chat room.",
         responses = {
             @ApiResponse(responseCode = "200", description = "Owner removed from the room."),
-            @ApiResponse(responseCode = "409", description = "When removal of this owner would leave the room without any owners (which is not allowed: a room must always have an owner).")
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "When removal of this owner would leave the room without any owners (which is not allowed: a room must always have an owner).", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomOwner(
         @Parameter(description = "The (bare) JID of the entity that is to be removed as an owner of the room.", example = "john@example.org", required = true) @PathParam("jid") String jid,
@@ -90,7 +105,11 @@ public class MUCRoomOwnersService {
         description = "Removes all members of an Openfire user group as owner of a multi-user chat room.",
         responses = {
             @ApiResponse(responseCode = "200", description = "Owners removed from the room."),
-            @ApiResponse(responseCode = "409", description = "When removal of these owners would leave the room without any owners (which is not allowed: a room must always have an owner).")
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to remove this affiliation.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "When removal of these owners would leave the room without any owners (which is not allowed: a room must always have an owner).", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
     public Response deleteMUCRoomOwnerGroup(
         @Parameter(description = "The name of the user group from which all members will be removed as owners of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,


### PR DESCRIPTION
When requests are made against MUC services or rooms that do not exist (but are expected to), then the old implementation would return a HTTP 500 "Internal Server Error" response.

This commit explicitly checks if the MUC service/room that is used in the request exist, and return HTTP 404 "Not Found" when that's not the case.

I've also included more annotations that will cause Swagger to generate a more complete list of errors that are returned for MUC services.

this fixes #74