### PR TITLE
fixes #102: Reduce log level of error responses

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ REST API Plugin Changelog
 
 <p><b>1.8.1</b> ???</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/102'>#102</a>] - Reduce log level of error responses.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/99'>#99</a>] - Fix hard-coded link to localhost for OpenAPI yaml link in docs.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/96'>#96</a>] - Don't require auth for readiness/liveness endpoints</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2022-04-06</date>
+    <date>2022-05-11</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/src/java/org/jivesoftware/openfire/plugin/rest/exceptions/RESTExceptionMapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/exceptions/RESTExceptionMapper.java
@@ -59,9 +59,16 @@ public class RESTExceptionMapper implements ExceptionMapper<ServiceException> {
         errorResponse.setResource(exception.getResource());
         errorResponse.setMessage(exception.getMessage());
         errorResponse.setException(exception.getException());
-        LOG.error(
+
+        if (exception.getStatus() != null && exception.getStatus().getStatusCode() == 500) {
+            LOG.warn(
                 exception.getException() + ": " + exception.getMessage() + " with resource "
-                        + exception.getResource(), exception.getException());
+                    + exception.getResource(), exception.getException());
+        } else {
+            LOG.info(
+                exception.getException() + ": " + exception.getMessage() + " with resource "
+                    + exception.getResource(), exception.getException());
+        }
         
         ResponseBuilder responseBuilder = Response.status(exception.getStatus()).entity(errorResponse);
         List<MediaType> accepts = headers.getAcceptableMediaTypes();


### PR DESCRIPTION
When the plugin is returning an error, this is likely caused by user input, and not by an implementation issue in Openfire or the plugin. Lets not log to `error`.