### PR TITLE
fixes #105: New endpoints for bulk operations of MUC room affiliations

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ REST API Plugin Changelog
 
 <p><b>1.8.1</b> ???</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/105'>#105</a>] - New endpoints for bulk operations on MUC room affiliations.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/102'>#102</a>] - Reduce log level of error responses.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/99'>#99</a>] - Fix hard-coded link to localhost for OpenAPI yaml link in docs.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/96'>#96</a>] - Don't require auth for readiness/liveness endpoints</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2022-05-11</date>
+    <date>2022-06-01</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/readme.html
+++ b/readme.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Openfire REST API Plugin Readme</title>
+    <title>Welcome file</title>
     <link rel="stylesheet" href="https://stackedit.io/style.css" />
 </head>
 
@@ -55,9 +55,12 @@
                     <li><a href="#delete-a-chat-room-endpoint-to-delete-a-chat-room.">Delete a chat room Endpoint to delete a chat room.</a></li>
                     <li><a href="#update-a-chat-room-endpoint-to-update-a-chat-room.">Update a chat room Endpoint to update a chat room.</a></li>
                     <li><a href="#invite-user-to-a-chat-room">Invite user to a chat Room</a></li>
-                    <li><a href="#add-user-with-role-to-chat-room">Add user with role to chat room</a></li>
-                    <li><a href="#add-group-with-role-to-chat-room">Add group with role to chat room</a></li>
-                    <li><a href="#delete-a-user-from-a-chat-room-endpoint-to-remove-a-room-user-role.">Delete a user from a chat room Endpoint to remove a room user role.</a></li>
+                    <li><a href="#get-all-users-with-a-particular-affiliation-in-a-chat-room">Get all users with a particular affiliation in a chat room</a></li>
+                    <li><a href="#add-user-with-affiliation-to-chat-room">Add user with affiliation to chat room</a></li>
+                    <li><a href="#replace-all-users-with-a-affiliation-in-a-chat-room">Replace all users with a affiliation in a chat room</a></li>
+                    <li><a href="#add-multiple-users-with-a-affiliation-to-a-chat-room">Add multiple users with a affiliation to a chat room</a></li>
+                    <li><a href="#add-group-with-affiliation-to-chat-room">Add group with affiliation to chat room</a></li>
+                    <li><a href="#delete-a-user-from-a-chat-room-endpoint-to-remove-a-room-user-affiliation.">Delete a user from a chat room Endpoint to remove a room user affiliation.</a></li>
                 </ul>
             </li>
             <li><a href="#system-related-rest-endpoints">System related REST Endpoints</a>
@@ -1245,13 +1248,13 @@
                 <td></td>
             </tr>
             </tbody>
-        </table><h2 id="add-user-with-role-to-chat-room">Add user with role to chat room</h2>
-        <p>Endpoint to add a new user with role to a room.</p>
+        </table><h2 id="get-all-users-with-a-particular-affiliation-in-a-chat-room">Get all users with a particular affiliation in a chat room</h2>
+        <p>Retrieves a list of JIDs for all users with the specified affiliation in a multi-user chat room.</p>
         <blockquote>
-            <p><strong>POST</strong> /chatrooms/{roomName}/{roles}/{name}</p>
+            <p><strong>GET</strong> /chatrooms/{roomName}/{affiliation}</p>
         </blockquote>
         <p><strong>Payload:</strong> none</p>
-        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
         <h3 id="possible-parameters-24">Possible parameters</h3>
 
         <table>
@@ -1271,15 +1274,9 @@
                 <td></td>
             </tr>
             <tr>
-                <td>name</td>
+                <td>affiliation</td>
                 <td>@Path</td>
-                <td>The local username or the user JID</td>
-                <td></td>
-            </tr>
-            <tr>
-                <td>roles</td>
-                <td>@Path</td>
-                <td>Available roles: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
+                <td>Available affiliations: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
                 <td></td>
             </tr>
             <tr>
@@ -1292,20 +1289,18 @@
         </table><h3 id="examples-22">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <blockquote>
-                <p><strong>Header:</strong> Content-Type application/xml<br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser</a><br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com</a><br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser</a><br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser</a><br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser</a><br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf</a></p>
-            </blockquote>
+            <p><strong>Header:</strong> Content-Type application/xml</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/member">http://example.org:9090/plugins/restapi/v1/chatrooms/global/member</a></p>
         </blockquote>
-        <h2 id="add-group-with-role-to-chat-room">Add group with role to chat room</h2>
-        <p>Endpoint to add a new group with role to a room.</p>
+        <p><strong>Return payload:</strong></p>
+        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span>
+</code></pre>
+        <h2 id="add-user-with-affiliation-to-chat-room">Add user with affiliation to chat room</h2>
+        <p>Endpoint to add a new user with affiliation to a room.</p>
         <blockquote>
-            <p><strong>POST</strong> /chatrooms/{roomName}/{roles}/group/{name}</p>
+            <p><strong>POST</strong> /chatrooms/{roomName}/{affiliation}/{name}</p>
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
@@ -1330,13 +1325,13 @@
             <tr>
                 <td>name</td>
                 <td>@Path</td>
-                <td>The group name</td>
+                <td>The local username or the user JID</td>
                 <td></td>
             </tr>
             <tr>
-                <td>roles</td>
+                <td>affiliation</td>
                 <td>@Path</td>
-                <td>Available roles: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
+                <td>Available affiliations: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
                 <td></td>
             </tr>
             <tr>
@@ -1350,6 +1345,161 @@
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
+                <p><strong>Header:</strong> Content-Type application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser@openfire.com</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser">http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser</a><br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf</a></p>
+            </blockquote>
+        </blockquote>
+        <h2 id="replace-all-users-with-a-affiliation-in-a-chat-room">Replace all users with a affiliation in a chat room</h2>
+        <p>Endpoint to replace all users with a particular affiliation in a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user using a particular affiliation, any other pre-existing affiliation is removed.</p>
+        <blockquote>
+            <p><strong>PUT</strong> /chatrooms/{roomName}/{affiliation}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> list of affiliations</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <h3 id="possible-parameters-26">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>roomname</td>
+                <td>@Path</td>
+                <td>Exact room name</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>affiliation</td>
+                <td>@Path</td>
+                <td>Available affiliations: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>servicename</td>
+                <td>@QueryParam</td>
+                <td>The name of the Group Chat Service</td>
+                <td>conference</td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-24">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>Header:</strong> Content-Type application/xml</p>
+            <p><strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members</a></p>
+        </blockquote>
+        <p><strong>Request Payload:</strong></p>
+        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span>
+</code></pre>
+        <h2 id="add-multiple-users-with-a-affiliation-to-a-chat-room">Add multiple users with a affiliation to a chat room</h2>
+        <p>Endpoint to add multiple users with an affiliation to a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user using a particular affiliation, any other pre-existing affiliation is removed.</p>
+        <blockquote>
+            <p><strong>PUT</strong> /chatrooms/{roomName}/{affiliation}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> list of affiliations</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <h3 id="possible-parameters-27">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>roomname</td>
+                <td>@Path</td>
+                <td>Exact room name</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>affiliation</td>
+                <td>@Path</td>
+                <td>Available affiliation: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>servicename</td>
+                <td>@QueryParam</td>
+                <td>The name of the Group Chat Service</td>
+                <td>conference</td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-25">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>Header:</strong> Content-Type application/xml</p>
+            <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/members">http://example.org:9090/plugins/restapi/v1/chatrooms/global/members</a></p>
+        </blockquote>
+        <p><strong>Request Payload:</strong></p>
+        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>members</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member2@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>member</span><span class="token punctuation">&gt;</span></span>member1@localhost<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>member</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>members</span><span class="token punctuation">&gt;</span></span>
+</code></pre>
+        <h2 id="add-group-with-affiliation-to-chat-room">Add group with affiliation to chat room</h2>
+        <p>Endpoint to add a new group with affiliation to a room.</p>
+        <blockquote>
+            <p><strong>POST</strong> /chatrooms/{roomName}/{affiliation}/group/{name}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <h3 id="possible-parameters-28">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>roomname</td>
+                <td>@Path</td>
+                <td>Exact room name</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>name</td>
+                <td>@Path</td>
+                <td>The group name</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>affiliation</td>
+                <td>@Path</td>
+                <td>Available affiliations: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>servicename</td>
+                <td>@QueryParam</td>
+                <td>The name of the Group Chat Service</td>
+                <td>conference</td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-26">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
                 <p><strong>Header:</strong> Content-Type application/xml</p>
             </blockquote>
             <p><strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testGroup">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testGroup</a></p>
@@ -1360,13 +1510,13 @@
                     <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testUser?servicename=privateconf">http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/group/testUser?servicename=privateconf</a></p>
             </blockquote>
         </blockquote>
-        <h2 id="delete-a-user-from-a-chat-room-endpoint-to-remove-a-room-user-role.">Delete a user from a chat room Endpoint to remove a room user role.</h2>
+        <h2 id="delete-a-user-from-a-chat-room-endpoint-to-remove-a-room-user-affiliation.">Delete a user from a chat room Endpoint to remove a room user affiliation.</h2>
         <blockquote>
-            <p><strong>DELETE</strong> /chatrooms/{roomName}/{roles}/{name}</p>
+            <p><strong>DELETE</strong> /chatrooms/{roomName}/{affiliations}/{name}</p>
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-26">Possible parameters</h3>
+        <h3 id="possible-parameters-29">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1391,9 +1541,9 @@
                 <td></td>
             </tr>
             <tr>
-                <td>roles</td>
+                <td>affiliations</td>
                 <td>@Path</td>
-                <td>Available roles: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
+                <td>Available affiliations: <br><strong>owners</strong>  <br> <strong>admins</strong> <br> <strong>members</strong> <br> <strong>outcasts</strong></td>
                 <td></td>
             </tr>
             <tr>
@@ -1403,7 +1553,7 @@
                 <td>conference</td>
             </tr>
             </tbody>
-        </table><h3 id="examples-24">Examples</h3>
+        </table><h3 id="examples-27">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
@@ -1423,7 +1573,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> System properties</p>
-        <h3 id="examples-25">Examples</h3>
+        <h3 id="examples-28">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
@@ -1436,89 +1586,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> System property</p>
-        <h3 id="possible-parameters-27">Possible parameters</h3>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Parameter Type</th>
-                <th>Description</th>
-                <th>Default value</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>propertyName</td>
-                <td>@Path</td>
-                <td>The name of system property</td>
-                <td></td>
-            </tr>
-            </tbody>
-        </table><h3 id="examples-26">Examples</h3>
-        <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain">http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain</a></p>
-        </blockquote>
-        <h2 id="create-a-system-property-endpoint-to-create-a-system-property">Create a system property Endpoint to create a system property</h2>
-        <blockquote>
-            <p><strong>POST</strong> system/properties</p>
-        </blockquote>
-        <p><strong>Payload:</strong> System Property</p>
-        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
-        <h3 id="examples-27">Examples</h3>
-        <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <blockquote>
-                <p><strong>Header:</strong> Content-Type: application/xml<br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties">http://example.org:9090/plugins/restapi/v1/system/properties</a></p>
-            </blockquote>
-        </blockquote>
-        <p><strong>Payload Example:</strong></p>
-        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>propertyName<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>propertyValue<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span>
-</code></pre>
-        <h2 id="delete-a-system-property">Delete a system property</h2>
-        <p>Endpoint to delete a system property</p>
-        <blockquote>
-            <p><strong>DELETE</strong> /system/properties/{propertyName}</p>
-        </blockquote>
-        <p><strong>Payload:</strong> none</p>
-        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-28">Possible parameters</h3>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Parameter Type</th>
-                <th>Description</th>
-                <th>Default value</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>propertyName</td>
-                <td>@Path</td>
-                <td>The name of system property</td>
-                <td></td>
-            </tr>
-            </tbody>
-        </table><h3 id="examples-28">Examples</h3>
-        <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <blockquote>
-                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
-            </blockquote>
-        </blockquote>
-        <h2 id="update-a-system-property">Update a system property</h2>
-        <p>Endpoint to update / overwrite a system property</p>
-        <blockquote>
-            <p><strong>PUT</strong> /system/properties/{propertyName}</p>
-        </blockquote>
-        <p><strong>Payload:</strong> System property</p>
-        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-29">Possible parameters</h3>
+        <h3 id="possible-parameters-30">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1540,6 +1608,88 @@
         </table><h3 id="examples-29">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain">http://example.org:9090/plugins/restapi/v1/system/properties/xmpp.domain</a></p>
+        </blockquote>
+        <h2 id="create-a-system-property-endpoint-to-create-a-system-property">Create a system property Endpoint to create a system property</h2>
+        <blockquote>
+            <p><strong>POST</strong> system/properties</p>
+        </blockquote>
+        <p><strong>Payload:</strong> System Property</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <h3 id="examples-30">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties">http://example.org:9090/plugins/restapi/v1/system/properties</a></p>
+            </blockquote>
+        </blockquote>
+        <p><strong>Payload Example:</strong></p>
+        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>property</span> <span class="token attr-name">key</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>propertyName<span class="token punctuation">"</span></span> <span class="token attr-name">value</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">"</span>propertyValue<span class="token punctuation">"</span></span><span class="token punctuation">/&gt;</span></span>
+</code></pre>
+        <h2 id="delete-a-system-property">Delete a system property</h2>
+        <p>Endpoint to delete a system property</p>
+        <blockquote>
+            <p><strong>DELETE</strong> /system/properties/{propertyName}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-31">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>propertyName</td>
+                <td>@Path</td>
+                <td>The name of system property</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-31">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
+            </blockquote>
+        </blockquote>
+        <h2 id="update-a-system-property">Update a system property</h2>
+        <p>Endpoint to update / overwrite a system property</p>
+        <blockquote>
+            <p><strong>PUT</strong> /system/properties/{propertyName}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> System property</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-32">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>propertyName</td>
+                <td>@Path</td>
+                <td>The name of system property</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-32">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
                 <p><strong>Header:</strong> Content-Type application/xml<br>
                     <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/properties/propertyName">http://example.org:9090/plugins/restapi/v1/system/properties/propertyName</a></p>
@@ -1556,7 +1706,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> Sessions count</p>
-        <h3 id="examples-30">Examples</h3>
+        <h3 id="examples-33">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/system/statistics/sessions">http://example.org:9090/plugins/restapi/v1/system/statistics/sessions</a></p>
@@ -1617,7 +1767,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value</strong>: HTTP status 200 (OK). Any HTTP status outside the range 200-399 indicates failure.</p>
-        <h3 id="possible-parameters-30">Possible parameters</h3>
+        <h3 id="possible-parameters-33">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1649,7 +1799,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> Groups</p>
-        <h3 id="examples-31">Examples</h3>
+        <h3 id="examples-34">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
@@ -1662,90 +1812,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> Group</p>
-        <h3 id="possible-parameters-31">Possible parameters</h3>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Parameter Type</th>
-                <th>Description</th>
-                <th>Default value</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>groupName</td>
-                <td>@Path</td>
-                <td>The name of the group</td>
-                <td></td>
-            </tr>
-            </tbody>
-        </table><h3 id="examples-32">Examples</h3>
-        <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/moderators">http://example.org:9090/plugins/restapi/v1/groups/moderators</a></p>
-        </blockquote>
-        <h2 id="create-a-group-endpoint-to-create-a-new-group">Create a group Endpoint to create a new group</h2>
-        <blockquote>
-            <p><strong>POST</strong> /groups</p>
-        </blockquote>
-        <p><strong>Payload:</strong> Group</p>
-        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
-        <h3 id="examples-33">Examples</h3>
-        <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <blockquote>
-                <p><strong>Header:</strong> Content-Type: application/xml<br>
-                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups">http://example.org:9090/plugins/restapi/v1/groups</a></p>
-            </blockquote>
-        </blockquote>
-        <p><strong>Payload Example:</strong></p>
-        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>
- <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>GroupName<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Some description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>isshared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>isshared</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
-</code></pre>
-        <h2 id="delete-a-group">Delete a group</h2>
-        <p>Endpoint to delete a group</p>
-        <blockquote>
-            <p><strong>DELETE</strong> /groups/{groupName}</p>
-        </blockquote>
-        <p><strong>Payload:</strong> none</p>
-        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-32">Possible parameters</h3>
-
-        <table>
-            <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Parameter Type</th>
-                <th>Description</th>
-                <th>Default value</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>groupName</td>
-                <td>@Path</td>
-                <td>The name of the group</td>
-                <td></td>
-            </tr>
-            </tbody>
-        </table><h3 id="examples-34">Examples</h3>
-        <blockquote>
-            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
-            <blockquote>
-                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupToDelete">http://example.org:9090/plugins/restapi/v1/groups/groupToDelete</a></p>
-            </blockquote>
-        </blockquote>
-        <h2 id="update-a-group">Update a group</h2>
-        <p>Endpoint to update / overwrite a group</p>
-        <blockquote>
-            <p><strong>PUT</strong> /groups/{groupName}</p>
-        </blockquote>
-        <p><strong>Payload:</strong> Group</p>
-        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-33">Possible parameters</h3>
+        <h3 id="possible-parameters-34">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1767,6 +1834,89 @@
         </table><h3 id="examples-35">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/moderators">http://example.org:9090/plugins/restapi/v1/groups/moderators</a></p>
+        </blockquote>
+        <h2 id="create-a-group-endpoint-to-create-a-new-group">Create a group Endpoint to create a new group</h2>
+        <blockquote>
+            <p><strong>POST</strong> /groups</p>
+        </blockquote>
+        <p><strong>Payload:</strong> Group</p>
+        <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
+        <h3 id="examples-36">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>Header:</strong> Content-Type: application/xml<br>
+                    <strong>POST</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups">http://example.org:9090/plugins/restapi/v1/groups</a></p>
+            </blockquote>
+        </blockquote>
+        <p><strong>Payload Example:</strong></p>
+        <pre class=" language-xml"><code class="prism  language-xml"><span class="token prolog">&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;</span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>group</span><span class="token punctuation">&gt;</span></span>
+ <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>name</span><span class="token punctuation">&gt;</span></span>GroupName<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>name</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>description</span><span class="token punctuation">&gt;</span></span>Some description<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>description</span><span class="token punctuation">&gt;</span></span> <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>isshared</span><span class="token punctuation">&gt;</span></span>false<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>isshared</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>group</span><span class="token punctuation">&gt;</span></span>
+</code></pre>
+        <h2 id="delete-a-group">Delete a group</h2>
+        <p>Endpoint to delete a group</p>
+        <blockquote>
+            <p><strong>DELETE</strong> /groups/{groupName}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> none</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-35">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>groupName</td>
+                <td>@Path</td>
+                <td>The name of the group</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-37">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
+            <blockquote>
+                <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupToDelete">http://example.org:9090/plugins/restapi/v1/groups/groupToDelete</a></p>
+            </blockquote>
+        </blockquote>
+        <h2 id="update-a-group">Update a group</h2>
+        <p>Endpoint to update / overwrite a group</p>
+        <blockquote>
+            <p><strong>PUT</strong> /groups/{groupName}</p>
+        </blockquote>
+        <p><strong>Payload:</strong> Group</p>
+        <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
+        <h3 id="possible-parameters-36">Possible parameters</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Parameter Type</th>
+                <th>Description</th>
+                <th>Default value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>groupName</td>
+                <td>@Path</td>
+                <td>The name of the group</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table><h3 id="examples-38">Examples</h3>
+        <blockquote>
+            <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
                 <p><strong>Header:</strong> Content-Type application/xml<br>
                     <strong>PUT</strong> <a href="http://example.org:9090/plugins/restapi/v1/groups/groupNameToUpdate">http://example.org:9090/plugins/restapi/v1/groups/groupNameToUpdate</a></p>
@@ -1785,7 +1935,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> Sessions</p>
-        <h3 id="examples-36">Examples</h3>
+        <h3 id="examples-39">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
@@ -1799,7 +1949,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> Sessions</p>
-        <h3 id="possible-parameters-34">Possible parameters</h3>
+        <h3 id="possible-parameters-37">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1818,7 +1968,7 @@
                 <td></td>
             </tr>
             </tbody>
-        </table><h3 id="examples-37">Examples</h3>
+        </table><h3 id="examples-40">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions/testuser">http://example.org:9090/plugins/restapi/v1/sessions/testuser</a></p>
@@ -1830,7 +1980,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> HTTP status 200 (OK)</p>
-        <h3 id="possible-parameters-35">Possible parameters</h3>
+        <h3 id="possible-parameters-38">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1849,7 +1999,7 @@
                 <td></td>
             </tr>
             </tbody>
-        </table><h3 id="examples-38">Examples</h3>
+        </table><h3 id="examples-41">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <p><strong>DELETE</strong> <a href="http://example.org:9090/plugins/restapi/v1/sessions/testuser">http://example.org:9090/plugins/restapi/v1/sessions/testuser</a></p>
@@ -1862,7 +2012,7 @@
         </blockquote>
         <p><strong>Payload:</strong> Message</p>
         <p><strong>Return value:</strong> HTTP status 201 (Created)</p>
-        <h3 id="examples-39">Examples</h3>
+        <h3 id="examples-42">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
@@ -1882,7 +2032,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> Security Audit Logs</p>
-        <h3 id="possible-parameters-36">Possible parameters</h3>
+        <h3 id="possible-parameters-39">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1925,7 +2075,7 @@
                 <td></td>
             </tr>
             </tbody>
-        </table><h3 id="examples-40">Examples</h3>
+        </table><h3 id="examples-43">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
             <blockquote>
@@ -1941,7 +2091,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> ClusterNodes</p>
-        <h3 id="examples-41">Examples</h3>
+        <h3 id="examples-44">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/nodes">http://example.org:9090/plugins/restapi/v1/clustering/nodes</a></p>
@@ -1954,7 +2104,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> ClusterNode</p>
-        <h3 id="possible-parameters-37">Possible parameters</h3>
+        <h3 id="possible-parameters-40">Possible parameters</h3>
 
         <table>
             <thead>
@@ -1973,7 +2123,7 @@
                 <td></td>
             </tr>
             </tbody>
-        </table><h3 id="examples-42">Examples</h3>
+        </table><h3 id="examples-45">Examples</h3>
         <blockquote>
             <p><strong>Header:</strong> Authorization: Basic YWRtaW46MTIzNDU=</p>
             <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/nodes/52a89928-66f7-45fd-9bb8-096de07400ac">http://example.org:9090/plugins/restapi/v1/clustering/nodes/52a89928-66f7-45fd-9bb8-096de07400ac</a></p>
@@ -1985,7 +2135,7 @@
         </blockquote>
         <p><strong>Payload:</strong> none</p>
         <p><strong>Return value:</strong> String describing the clustering status of this Openfire instance</p>
-        <h3 id="examples-43">Examples</h3>
+        <h3 id="examples-46">Examples</h3>
         <blockquote>
             <p><strong>Header</strong>: Authorization: Basic YWRtaW46MTIzNDU=</p>
             <p><strong>GET</strong> <a href="http://example.org:9090/plugins/restapi/v1/clustering/status">http://example.org:9090/plugins/restapi/v1/clustering/status</a></p>

--- a/readme.md
+++ b/readme.md
@@ -1027,9 +1027,42 @@ Endpoint to invite a user to a room.
 | roomname  | 	@Path	         | Exact room name                    |               |
 | name      | @Path	          | The local username or the user JID |               |
 
-##  Add user with role to chat room
-Endpoint to add a new user with role to a room.
->**POST** /chatrooms/{roomName}/{roles}/{name}
+##  Get all users with a particular affiliation in a chat room
+Retrieves a list of JIDs for all users with the specified affiliation in a multi-user chat room.
+
+>**GET** /chatrooms/{roomName}/{affiliation}
+
+**Payload:** none
+
+**Return value:** HTTP status 200 (OK)
+
+### Possible parameters
+
+| Parameter   | 	Parameter Type | Description                                                                                | Default value |
+|-------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname    | 	@Path	         | Exact room name                                                                            |               |
+| affiliation | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
+
+### Examples
+>**Header:** Authorization: Basic YWRtaW46MTIzNDU=
+>
+>**Header:** Content-Type application/xml
+>
+>**GET** http://example.org:9090/plugins/restapi/v1/chatrooms/global/member
+
+**Return payload:**
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<members>
+    <member>member2@localhost</member>
+    <member>member1@localhost</member>
+</members>
+```
+
+##  Add user with affiliation to chat room
+Endpoint to add a new user with affiliation to a room.
+>**POST** /chatrooms/{roomName}/{affiliation}/{name}
 
 **Payload:** none
 
@@ -1037,12 +1070,12 @@ Endpoint to add a new user with role to a room.
 
 ### Possible parameters
 
-| Parameter   | 	Parameter Type | Description                                                                         | Default value |
-|-------------|-----------------|-------------------------------------------------------------------------------------|---------------|
-| roomname    | 	@Path	         | Exact room name                                                                     |               |
-| name        | 	@Path	         | The local username or the user JID                                                  |               |
-| roles       | 	@Path	         | Available roles: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                  | conference    |
+| Parameter   | 	Parameter Type | Description                                                                                | Default value |
+|-------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname    | 	@Path	         | Exact room name                                                                            |               |
+| name        | 	@Path	         | The local username or the user JID                                                         |               |
+| affiliation | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=
@@ -1061,9 +1094,73 @@ Endpoint to add a new user with role to a room.
 > 
 >**POST** http://example.org:9090/plugins/restapi/v1/chatrooms/global/owners/testUser?servicename=privateconf
 
-##  Add group with role to chat room
-Endpoint to add a new group with role to a room.
->**POST** /chatrooms/{roomName}/{roles}/group/{name}
+##  Replace all users with a affiliation in a chat room
+Endpoint to replace all users with a particular affiliation in a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user using a particular affiliation, any other pre-existing affiliation is removed.
+>**PUT** /chatrooms/{roomName}/{affiliation}
+
+**Payload:** list of affiliations
+
+**Return value:** HTTP status 201 (Created)
+
+### Possible parameters
+
+| Parameter   | 	Parameter Type | Description                                                                                | Default value |
+|-------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname    | 	@Path	         | Exact room name                                                                            |               |
+| affiliation | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
+
+### Examples
+>**Header:** Authorization: Basic YWRtaW46MTIzNDU=
+>
+>**Header:** Content-Type application/xml
+>
+>**PUT** http://example.org:9090/plugins/restapi/v1/chatrooms/global/members
+> 
+**Request Payload:**
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<members>
+    <member>member2@localhost</member>
+    <member>member1@localhost</member>
+</members>
+```
+
+##  Add multiple users with a affiliation to a chat room
+Endpoint to add multiple users with an affiliation to a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user using a particular affiliation, any other pre-existing affiliation is removed.
+>**PUT** /chatrooms/{roomName}/{affiliation}
+
+**Payload:** list of affiliations
+
+**Return value:** HTTP status 201 (Created)
+
+### Possible parameters
+
+| Parameter    | 	Parameter Type | Description                                                                         | Default value |
+|--------------|-----------------|-------------------------------------------------------------------------------------|---------------|
+| roomname     | 	@Path	         | Exact room name                                                                     |               |
+| affiliation  | 	@Path	         | Available affiliation: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename  | 	@QueryParam	   | The name of the Group Chat Service                                                  | conference    |
+
+### Examples
+>**Header:** Authorization: Basic YWRtaW46MTIzNDU=
+>
+>**Header:** Content-Type application/xml
+>
+>**POST** http://example.org:9090/plugins/restapi/v1/chatrooms/global/members
+>
+**Request Payload:**
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<members>
+    <member>member2@localhost</member>
+    <member>member1@localhost</member>
+</members>
+```
+
+##  Add group with affiliation to chat room
+Endpoint to add a new group with affiliation to a room.
+>**POST** /chatrooms/{roomName}/{affiliation}/group/{name}
 
 **Payload:** none
 
@@ -1071,12 +1168,12 @@ Endpoint to add a new group with role to a room.
 
 ### Possible parameters
 
-| Parameter   | Parameter Type | Description                                                                         | Default value |
-|-------------|----------------|-------------------------------------------------------------------------------------|---------------|
-| roomname    | @Path          | Exact room name                                                                     |               |
-| name        | @Path          | The group name                                                                      |               |
-| roles       | @Path          | Available roles: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename | @QueryParam    | The name of the Group Chat Service                                                  | conference    |
+| Parameter   | Parameter Type | Description                                                                                | Default value |
+|-------------|----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname    | @Path          | Exact room name                                                                            |               |
+| name        | @Path          | The group name                                                                             |               |
+| affiliation | @Path          | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename | @QueryParam    | The name of the Group Chat Service                                                         | conference    |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=
@@ -1095,8 +1192,8 @@ Endpoint to add a new group with role to a room.
 
 
 ## Delete a user from a chat room 
-Endpoint to remove a room user role.
->**DELETE** /chatrooms/{roomName}/{roles}/{name}
+Endpoint to remove a room user affiliation.
+>**DELETE** /chatrooms/{roomName}/{affiliations}/{name}
 
 **Payload:** none
 
@@ -1104,12 +1201,12 @@ Endpoint to remove a room user role.
 
 ### Possible parameters
 
-| Parameter   | 	Parameter Type | Description                                                                         | Default value |
-|-------------|-----------------|-------------------------------------------------------------------------------------|---------------|
-| roomname    | 	@Path	         | Exact room name                                                                     |               |
-| name        | 	@Path	         | The local username or the user JID                                                  |               |
-| roles       | 	@Path	         | Available roles: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                  | conference    |
+| Parameter    | 	Parameter Type | Description                                                                                | Default value |
+|--------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname     | 	@Path	         | Exact room name                                                                            |               |
+| name         | 	@Path	         | The local username or the user JID                                                         |               |
+| affiliations | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename  | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/AdminEntities.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/AdminEntities.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.plugin.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "admins")
+public class AdminEntities
+{
+    List<String> admins;
+
+    public AdminEntities() {
+    }
+
+    public AdminEntities(List<String> admins) {
+        this.admins = admins;
+    }
+
+    @XmlElement(name = "admin")
+    @JsonProperty(value = "admins")
+    public List<String> getAdmins() {
+        return admins;
+    }
+
+    public void setAdmins(List<String> admins) {
+        this.admins = admins;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/MemberEntities.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/MemberEntities.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.plugin.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "members")
+public class MemberEntities
+{
+    List<String> members;
+
+    public MemberEntities() {
+    }
+
+    public MemberEntities(List<String> members) {
+        this.members = members;
+    }
+
+    @XmlElement(name = "member")
+    @JsonProperty(value = "members")
+    public List<String> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<String> members) {
+        this.members = members;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/OutcastEntities.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/OutcastEntities.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.plugin.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "outcasts")
+public class OutcastEntities
+{
+    List<String> outcasts;
+
+    public OutcastEntities() {
+    }
+
+    public OutcastEntities(List<String> outcasts) {
+        this.outcasts = outcasts;
+    }
+
+    @XmlElement(name = "outcast")
+    @JsonProperty(value = "outcasts")
+    public List<String> getOutcasts() {
+        return outcasts;
+    }
+
+    public void setOutcasts(List<String> outcasts) {
+        this.outcasts = outcasts;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/OwnerEntities.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/OwnerEntities.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.plugin.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "owners")
+public class OwnerEntities
+{
+    List<String> owners;
+
+    public OwnerEntities() {
+    }
+
+    public OwnerEntities(List<String> owners) {
+        this.owners = owners;
+    }
+
+    @XmlElement(name = "owner")
+    @JsonProperty(value = "owners")
+    public List<String> getOwners() {
+        return owners;
+    }
+
+    public void setOwners(List<String> owners) {
+        this.owners = owners;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAdminsService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAdminsService.java
@@ -20,24 +20,99 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.jivesoftware.openfire.muc.MUCRole;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
+import org.jivesoftware.openfire.plugin.rest.entity.AdminEntities;
+import org.jivesoftware.openfire.plugin.rest.entity.OwnerEntities;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ErrorResponse;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.xmpp.packet.JID;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Path("restapi/v1/chatrooms/{roomName}/admins")
 @Tag(name = "Chat room", description = "Managing Multi-User chat rooms.")
 public class MUCRoomAdminsService {
 
+    @GET
+    @Path("/")
+    @Operation( summary = "All room admins",
+        description = "Retrieves a list of JIDs for all administrators of a multi-user chat room.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "Admin list retrieved."),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        })
+    public Response getAdmins(
+        @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
+        @Parameter(description = "The name of the MUC room for which to return admins.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+        throws ServiceException
+    {
+        final List<String> results = MUCRoomController.getInstance().getByAffiliation(serviceName, roomName, MUCRole.Affiliation.admin).stream()
+            .map(JID::toBareJID)
+            .collect(Collectors.toList());
+        return Response.ok(new AdminEntities(results)).build();
+    }
+
+    @PUT
+    @Path("/")
+    @Operation( summary = "Replace room admins",
+        description = "Replaces the room admins in a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user as a room admin, any other pre-existing affiliation is removed.",
+        responses = {
+            @ApiResponse(responseCode = "201", description = "Admins of the room have been replaced."),
+            @ApiResponse(responseCode = "400", description = "Provided values cannot be parsed as JIDs.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to modify a room admins.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        })
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public Response replaceMUCRoomAdmins(
+        @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
+        @Parameter(description = "The name of the MUC room of which admins are to be replaced.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @RequestBody(description = "The new list of room admins.", required = true) AdminEntities adminEntities)
+        throws ServiceException
+    {
+        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.admin, adminEntities.getAdmins());
+        return Response.status(Status.CREATED).build();
+    }
+
+    @POST
+    @Path("/")
+    @Operation( summary = "Add room admins",
+        description = "Add multiple room admins in a multi-user chat room (without removing existing admins). Note that a user can only have one type of affiliation with a room. By adding a user as a room admin, any other pre-existing affiliation is removed.",
+        responses = {
+            @ApiResponse(responseCode = "201", description = "Admins of the room have been added."),
+            @ApiResponse(responseCode = "400", description = "Provided values cannot be parsed as JIDs.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not allowed to modify a room admins.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "The chat room (or its service) can not be found or is not accessible.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected, generic error condition.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        })
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public Response addMUCRoomAdmins(
+        @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
+        @Parameter(description = "The name of the MUC room to which admins are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @RequestBody(description = "The list of room admins to add to the room.", required = true) AdminEntities adminEntities)
+        throws ServiceException
+    {
+        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.admin, adminEntities.getAdmins());
+        return Response.status(Status.CREATED).build();
+    }
+
     @POST
     @Path("/{jid}")
     @Operation( summary = "Add room admin",
-        description = "Adds an administrator to a multi-user chat room.",
+        description = "Adds an administrator to a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user as a room admin, any other pre-existing affiliation is removed.",
         responses = {
             @ApiResponse(responseCode = "201", description = "Administrator added to the room."),
             @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -58,7 +133,7 @@ public class MUCRoomAdminsService {
     @POST
     @Path("/group/{groupname}")
     @Operation( summary = "Add room admins",
-        description = "Adds all members of an Openfire user group as administrator to a multi-user chat room.",
+        description = "Adds all members of an Openfire user group as administrator to a multi-user chat room. Note that a user can only have one type of affiliation with a room. By adding a user as a room admin, any other pre-existing affiliation is removed.",
         responses = {
             @ApiResponse(responseCode = "201", description = "Administrators added to the room."),
             @ApiResponse(responseCode = "401", description = "Web service authentication failed.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -94,7 +169,6 @@ public class MUCRoomAdminsService {
             @Parameter(description = "The name of the MUC room from which an administrator is to be removed.", example = "lobby", required = true) @PathParam("roomName") String roomName)
         throws ServiceException
     {
-        // FIXME: check if this removes _all_ affiliations, which probably would be more than we're bargaining for.
         MUCRoomController.getInstance().deleteAffiliation(serviceName, roomName, jid);
         return Response.status(Status.OK).build();
     }
@@ -117,7 +191,6 @@ public class MUCRoomAdminsService {
         @Parameter(description = "The name of the MUC room to which administrators are to be removed.", example = "lobby", required = true) @PathParam("roomName") String roomName)
         throws ServiceException
     {
-        // FIXME: check if this removes _all_ affiliations, which probably would be more than we're bargaining for.
         MUCRoomController.getInstance().deleteAffiliation(serviceName, roomName, groupname);
         return Response.status(Status.OK).build();
     }


### PR DESCRIPTION
This adds three new types of endpoints:
1. return all JIDs that have a particular affiliation to a particular chatroom:
`GET /restapi/v1/chatrooms/{room}/{affiliation}?servicename=conference`

2. replace all JIDs that have a particular affiliation to a particular chatroom:
`PUT /restapi/v1/chatrooms/{room}/{affiliation}?servicename=conference`

3. add multiplple JIDs with a particular affilaition to a particular chatroom:
`POST /restapi/v1/chatrooms/{room}/{affiliation}?servicename=conference`

This should make it a lot easier to make bulk operations. Prior to this commit, changes had to be applied one-by-one.