### PR TITLE
fixes 108: Do not verbosely log non-existence of entity when performing HEAD request

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ REST API Plugin Changelog
 
 <p><b>1.8.1</b> ???</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/108'>#108</a>] - On existence (HEAD) check, do not log absence of entity verbosely.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/105'>#105</a>] - New endpoints for bulk operations on MUC room affiliations.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/102'>#102</a>] - Reduce log level of error responses.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/99'>#99</a>] - Fix hard-coded link to localhost for OpenAPI yaml link in docs.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2022-06-01</date>
+    <date>2022-06-22</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/src/java/org/jivesoftware/openfire/plugin/rest/exceptions/RESTExceptionMapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/exceptions/RESTExceptionMapper.java
@@ -16,18 +16,15 @@
 
 package org.jivesoftware.openfire.plugin.rest.exceptions;
 
-import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 
 /**
  * The Class RESTExceptionMapper.
@@ -41,7 +38,9 @@ public class RESTExceptionMapper implements ExceptionMapper<ServiceException> {
     /** The headers. */
     @Context
     private HttpHeaders headers;
-    
+
+    @Context
+    private HttpServletRequest request;
 
     /**
      * Instantiates a new REST exception mapper.
@@ -64,6 +63,9 @@ public class RESTExceptionMapper implements ExceptionMapper<ServiceException> {
             LOG.warn(
                 exception.getException() + ": " + exception.getMessage() + " with resource "
                     + exception.getResource(), exception.getException());
+        } else if (exception.getStatus().getStatusCode() == 404 && "HEAD".equalsIgnoreCase(request.getMethod())) {
+            // This is an existence check that has a 'nope' answer that is perfectly valid. This should not be logged by default.
+            LOG.debug(exception.getException() + ": " + exception.getMessage() + " with resource " + exception.getResource());
         } else {
             LOG.info(
                 exception.getException() + ": " + exception.getMessage() + " with resource "


### PR DESCRIPTION
A HEAD request can be performed to check if an entity exists. If the answer is 'no' (represented by a 404 status code), then this should not be logged on a level that automatically gets written to a log file. This prevents cluttering of the log file.