### PR TITLE
Update cache when creating or updating MUCs

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.8.2</b> ??? 2022</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/30'>#30</a>] - Update cache when creating or updating MUCs</li>
+</ul>
+
 <p><b>1.8.1</b> June 23, 2022</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/108'>#108</a>] - On existence (HEAD) check, do not log absence of entity verbosely.</li>

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -375,6 +375,8 @@ public class MUCRoomController {
         if (room.isPersistent()) {
             room.saveToDB();
         }
+
+        getService(serviceName).syncChatRoom(room);
     }
 
     private boolean equalToAffiliations(MUCRoom room, MUCRoomEntity mucRoomEntity) {


### PR DESCRIPTION
When clustering, the MUC goes into the cache, but doesn't get an ID, and the savedToDB value is incorrect. No idea if this has any real world impact, but it's certainly wrong. This forces a sync the same way that Admin does when it creates a room.

Could this be #30?