### PR TITLE
fixes 118: Return full room list from /chatrooms when not searching

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ REST API Plugin Changelog
 
 <p><b>1.8.3</b> ???</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/118'>#118</a>] - Cannot retrieve full list of rooms following #113</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/113'>#113</a>] - MUC search including naturalName</li>
 </ul>
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -175,12 +175,10 @@ public class MUCRoomController {
         List<MUCRoomEntity> mucRoomEntities = new ArrayList<>();
 
         for (MUCRoomSearchInfo roomInfo : roomsInfo) {
-            String roomName = "";
+            String roomName = roomInfo.getName();
             if (roomSearch != null) {
-                if (StringUtils.containsIgnoringCase(roomInfo.getName(), roomSearch) ||
-                    StringUtils.containsIgnoringCase(roomInfo.getNaturalLanguageName(), roomSearch)) {
-                    roomName = roomInfo.getName();
-                } else {
+                if (!StringUtils.containsIgnoringCase(roomInfo.getName(), roomSearch) &&
+                    !StringUtils.containsIgnoringCase(roomInfo.getNaturalLanguageName(), roomSearch)) {
                     continue;
                 }
             }


### PR DESCRIPTION
The fix for #113 didn't account for calling the endpoint without a search term, preventing the full list of rooms from being retrieved.

This switches some logic around to account for both search and non-search cases.

Looked at why the current tests didn't catch it, but those are service tests that rely on controller mocks. Any attempt to expand the tests now would orders of magnitude more effort than this fix is alone.