### PR TITLE
Dependency Updates

### DIFF
--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+       file name: jakarta.annotation-api-1.3.5.jar
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/jakarta\.annotation/jakarta\.annotation\-api@.*$</packageUrl>
+        <cpe>cpe:/a:projects_project:projects</cpe>
+    </suppress>
+</suppressions>

--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,11 @@ REST API Plugin Changelog
 
 <p><b>1.8.3</b> ???</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/124'>#124</a>] - Update dependency-check-maven to 7.1.1</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/123'>#123</a>] - Suppress false positive in Dependency Check</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/122'>#122</a>] - Update mockito to 4.6.1</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/121'>#121</a>] - Update Swagger to 2.2.1</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/120'>#120</a>] - Update Jersey to 2.36</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/113'>#113</a>] - MUC search including naturalName</li>
 </ul>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,9 @@
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipRuntimeScope>true</skipRuntimeScope>
+                            <suppressionFiles>
+                                <suppressionFile>.dependency-check-suppressions.xml</suppressionFile>
+                            </suppressionFiles>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.5.0</version>
+                        <version>7.1.1</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipRuntimeScope>true</skipRuntimeScope>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </licenses>
 
     <properties>
-        <jersey.version>2.35</jersey.version>
+        <jersey.version>2.36</jersey.version>
     </properties>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,12 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2</artifactId>
-            <version>2.1.11</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2-servlet-initializer-v2</artifactId>
-            <version>2.1.11</version>
+            <version>2.2.1</version>
         </dependency>
 
         <!-- Testing scope dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.3.1</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Solves some deps with open CVEs (and updates some other deps that don't).
Dependency Check is back to just Jetty complaints.