### PR TITLE
Send invitations to users and groups

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,8 @@ REST API Plugin Changelog
 <p><b>1.9.0</b> (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/130'>#130</a>] - Add endpoint to create a new MUC service</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/129'>#129</a>] - Add endpoint(s) to invite users to a chatroom</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/128'>#128</a>] - Modify endpoints to add 'send invitations to affiliated users' as optional functionality</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/127'>#127</a>] - Add endpoint that allows for more than one MUC room to be created with one request</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/33'>#33</a>] - Add 'allowPM' to representation of MUC room.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/15'>#15</a>] - Fix group-based affiliations with MUC rooms.</li>

--- a/readme.md
+++ b/readme.md
@@ -804,9 +804,10 @@ Endpoint to create a new chat room.
 
 ### Possible parameters
 
-| Parameter   | Parameter Type	 | Description                         | Default value |
-|-------------|-----------------|-------------------------------------|---------------|
-| servicename | @QueryParam     | 	The name of the Group Chat Service | conference    |
+| Parameter       | Parameter Type	 | Description                                     | Default value |
+|-----------------|-----------------|-------------------------------------------------|---------------|
+| servicename     | @QueryParam     | 	The name of the Group Chat Service             | conference    |
+| sendInvitations | @QueryParam     | Whether to send invitations to affiliated users | false         |
 
 ### XML Examples
 
@@ -1035,9 +1036,10 @@ Endpoint to create multiple new chat rooms at once.
 ```
 ### Possible parameters
 
-| Parameter   | Parameter Type	 | Description                         | Default value |
-|-------------|-----------------|-------------------------------------|---------------|
-| servicename | @QueryParam     | 	The name of the Group Chat Service | conference    |
+| Parameter       | Parameter Type	 | Description                                           | Default value |
+|-----------------|-----------------|-------------------------------------------------------|---------------|
+| servicename     | @QueryParam     | 	The name of the Group Chat Service                   | conference    |
+| sendInvitations | @QueryParam     | Whether to send invitations to newly affiliated users | false         |
 
 ### XML Examples
 
@@ -1125,10 +1127,11 @@ Endpoint to update a chat room.
 
 ### Possible parameters
 
-| Parameter   | 	Parameter Type | Description                        | Default value |
-|-------------|-----------------|------------------------------------|---------------|
-| roomname    | 	@Path	         | Exact room name                    |               |
-| servicename | 	@QueryParam	   | The name of the Group Chat Service | conference    |
+| Parameter       | Parameter Type | Description                                           | Default value |
+|-----------------|----------------|-------------------------------------------------------|---------------|
+| roomname        | @Path          | Exact room name                                       |               |
+| servicename     | @QueryParam    | The name of the Group Chat Service                    | conference    |
+| sendInvitations | @QueryParam    | Whether to send invitations to newly affiliated users | false         |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=
@@ -1178,9 +1181,9 @@ Endpoint to update a chat room.
 </chatRoom>
 ```
 
-## Invite user to a chat Room
+## Invite user or user group to a chat Room
 
-Endpoint to invite a user to a room.
+Endpoint to invite a user or a user group to a room.
 > **Header:** Authorization: Basic YWRtaW46MTIzNDU=
 > 
 > **Header:** Content-Type: application/xml
@@ -1198,10 +1201,40 @@ Endpoint to invite a user to a room.
 **Return value:** HTTP status 200 (OK)
 
 ### Possible parameters
-| Parameter | 	Parameter Type | Description                        | Default value |
-|-----------|-----------------|------------------------------------|---------------|
-| roomname  | 	@Path	         | Exact room name                    |               |
-| name      | @Path	          | The local username or the user JID |               |
+| Parameter | 	Parameter Type | Description                                                   | Default value |
+|-----------|-----------------|---------------------------------------------------------------|---------------|
+| roomname  | 	@Path	         | Exact room name                                               |               |
+| name      | @Path	          | The local username or group name or the user JID or group JID |               |
+
+## Invite multiple users and/or user groups to a chat Room
+
+Endpoint to invite multiple users and/or user groups to a room. Works both with JIDs and (user/group) names.
+> **Header:** Authorization: Basic YWRtaW46MTIzNDU=
+>
+> **Header:** Content-Type: application/xml
+>
+> **POST** http://localhost:9090/plugins/restapi/v1/chatrooms/{roomName}/invite
+
+**Payload Example:**
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mucInvitation>
+    <reason>Hello, come to this room, it is nice</reason>
+    <jidsToInvite>
+        <jid>jane@example.org</jid>
+        <jid>ADNMQP8=@example.org/695c6ae413c00446733d926ccadefd8b</jid>
+        <jid>john</jid>
+        <jid>SomeGroupName</jid>
+    </jidsToInvite>
+</mucInvitation>
+```
+**Return value:** HTTP status 200 (OK)
+
+### Possible parameters
+| Parameter | 	Parameter Type | Description                                                   | Default value |
+|-----------|-----------------|---------------------------------------------------------------|---------------|
+| roomname  | 	@Path	         | Exact room name                                               |               |
 
 ##  Get all users with a particular affiliation in a chat room
 Retrieves a list of JIDs for all users with the specified affiliation in a multi-user chat room.
@@ -1246,12 +1279,13 @@ Endpoint to add a new user with affiliation to a room.
 
 ### Possible parameters
 
-| Parameter   | 	Parameter Type | Description                                                                                | Default value |
-|-------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
-| roomname    | 	@Path	         | Exact room name                                                                            |               |
-| name        | 	@Path	         | The local username or the user JID                                                         |               |
-| affiliation | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
+| Parameter       | 	Parameter Type | Description                                                                                | Default value |
+|-----------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname        | 	@Path	         | Exact room name                                                                            |               |
+| name            | 	@Path	         | The local username or the user JID                                                         |               |
+| affiliation     | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename     | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
+| sendInvitations | @QueryParam     | Whether to send invitation to the newly affiliated user                                    | false         |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=
@@ -1264,7 +1298,7 @@ Endpoint to add a new user with affiliation to a room.
 > 
 >**POST** http://example.org:9090/plugins/restapi/v1/chatrooms/global/admins/testUser
 > 
->**POST** http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser
+>**POST** http://example.org:9090/plugins/restapi/v1/chatrooms/global/members/testUser?sendInvitations=true
 > 
 >**POST** http://example.org:9090/plugins/restapi/v1/chatrooms/global/outcasts/testUser
 > 
@@ -1280,11 +1314,12 @@ Endpoint to replace all users with a particular affiliation in a multi-user chat
 
 ### Possible parameters
 
-| Parameter   | 	Parameter Type | Description                                                                                | Default value |
-|-------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
-| roomname    | 	@Path	         | Exact room name                                                                            |               |
-| affiliation | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
+| Parameter       | 	Parameter Type | Description                                                                                | Default value |
+|-----------------|-----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname        | 	@Path	         | Exact room name                                                                            |               |
+| affiliation     | 	@Path	         | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename     | 	@QueryParam	   | The name of the Group Chat Service                                                         | conference    |
+| sendInvitations | @QueryParam     | Whether to send invitation to newly affiliated users                                       | false         |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=
@@ -1312,11 +1347,12 @@ Endpoint to add multiple users with an affiliation to a multi-user chat room. No
 
 ### Possible parameters
 
-| Parameter    | 	Parameter Type | Description                                                                         | Default value |
-|--------------|-----------------|-------------------------------------------------------------------------------------|---------------|
-| roomname     | 	@Path	         | Exact room name                                                                     |               |
-| affiliation  | 	@Path	         | Available affiliation: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename  | 	@QueryParam	   | The name of the Group Chat Service                                                  | conference    |
+| Parameter       | 	Parameter Type | Description                                                                               | Default value |
+|-----------------|-----------------|-------------------------------------------------------------------------------------------|---------------|
+| roomname        | 	@Path	         | Exact room name                                                                           |               |
+| affiliation     | 	@Path	         | Available affiliation: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename     | 	@QueryParam	   | The name of the Group Chat Service                                                        | conference    |
+| sendInvitations | @QueryParam     | Whether to send invitations to newly affiliated users                                     | false         |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=
@@ -1344,12 +1380,13 @@ Endpoint to add a new group with affiliation to a room.
 
 ### Possible parameters
 
-| Parameter   | Parameter Type | Description                                                                                | Default value |
-|-------------|----------------|--------------------------------------------------------------------------------------------|---------------|
-| roomname    | @Path          | Exact room name                                                                            |               |
-| name        | @Path          | The group name                                                                             |               |
-| affiliation | @Path          | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
-| servicename | @QueryParam    | The name of the Group Chat Service                                                         | conference    |
+| Parameter       | Parameter Type | Description                                                                                | Default value |
+|-----------------|----------------|--------------------------------------------------------------------------------------------|---------------|
+| roomname        | @Path          | Exact room name                                                                            |               |
+| name            | @Path          | The group name                                                                             |               |
+| affiliation     | @Path          | Available affiliations: <br>**owners**  <br> **admins** <br> **members** <br> **outcasts** |               |
+| servicename     | @QueryParam    | The name of the Group Chat Service                                                         | conference    |
+| sendInvitations | @QueryParam    | Whether to send invitations to the users in the newly affiliated groups                    | false         |
 
 ### Examples
 >**Header:** Authorization: Basic YWRtaW46MTIzNDU=

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationEntity.java
@@ -16,18 +16,27 @@
 
 package org.jivesoftware.openfire.plugin.rest.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
 
 @XmlRootElement(name = "mucInvitation")
 public class MUCInvitationEntity {
 
     String reason;
 
+    private List<String> jidsToInvite;
+
     public MUCInvitationEntity() {
     }
 
     @XmlElement
+    @Schema(description = "The reason that will be included in the invitation message(s)", example = "Come join this cool room please!")
     public String getReason() {
         return reason;
     }
@@ -36,4 +45,18 @@ public class MUCInvitationEntity {
         this.reason = reason;
     }
 
+    @XmlElementWrapper(name = "jidsToInvite")
+    @XmlElement(name = "jid")
+    @JsonProperty(value = "jidsToInvite")
+    @Schema(description = "The JIDs and/or names of the users and groups to invite into the room", example = "<jidsToInvite><jid>jane@example.org</jid></jidsToInvite>")
+    public List<String> getJidsToInvite() {
+        if (jidsToInvite == null) {
+            jidsToInvite = new ArrayList<>();
+        }
+        return jidsToInvite;
+    }
+
+    public void setJidsToInvite(List<String> jidsToInvite) {
+        this.jidsToInvite = jidsToInvite;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAdminsService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAdminsService.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jivesoftware.openfire.muc.MUCRole;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
 import org.jivesoftware.openfire.plugin.rest.entity.AdminEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.OwnerEntities;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ErrorResponse;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.xmpp.packet.JID;
@@ -79,10 +78,11 @@ public class MUCRoomAdminsService {
     public Response replaceMUCRoomAdmins(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the MUC room of which admins are to be replaced.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to newly affiliated admin users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations,
         @RequestBody(description = "The new list of room admins.", required = true) AdminEntities adminEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.admin, adminEntities.getAdmins());
+        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.admin, adminEntities.getAdmins(), sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -102,10 +102,11 @@ public class MUCRoomAdminsService {
     public Response addMUCRoomAdmins(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the MUC room to which admins are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to newly affiliated admin users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations,
         @RequestBody(description = "The list of room admins to add to the room.", required = true) AdminEntities adminEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.admin, adminEntities.getAdmins());
+        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.admin, adminEntities.getAdmins(), sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -123,10 +124,11 @@ public class MUCRoomAdminsService {
     public Response addMUCRoomAdmin(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
             @Parameter(description = "The (bare) JID of the entity that is to be added as an admin.", example = "john@example.org", required = true) @PathParam("jid") String jid,
-            @Parameter(description = "The name of the MUC room to which an administrator is to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+            @Parameter(description = "The name of the MUC room to which an administrator is to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+            @Parameter(description = "Whether to send an invitation to the new admin user.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addAdmin(serviceName, roomName, jid);
+        MUCRoomController.getInstance().addAdmin(serviceName, roomName, jid, sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -144,10 +146,11 @@ public class MUCRoomAdminsService {
     public Response addMUCRoomAdminGroup(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
             @Parameter(description = "The name of the user group from which all members will be administrators of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,
-            @Parameter(description = "The name of the MUC room to which administrators are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+            @Parameter(description = "The name of the MUC room to which administrators are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+            @Parameter(description = "Whether to send invitations to new admin users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addAdmin(serviceName, roomName, groupname);
+        MUCRoomController.getInstance().addAdmin(serviceName, roomName, groupname, sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersService.java
@@ -79,10 +79,11 @@ public class MUCRoomMembersService {
     public Response replaceMUCRoomMembers(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the MUC room of which members are to be replaced.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to newly affiliated users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations,
         @RequestBody(description = "The new list of room members.", required = true) MemberEntities memberEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.member, memberEntities.getMembers());
+        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.member, memberEntities.getMembers(), sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -102,10 +103,11 @@ public class MUCRoomMembersService {
     public Response addMUCRoomMembers(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the MUC room to which members are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to newly affiliated users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations,
         @RequestBody(description = "The list of room members to add to the room.", required = true) MemberEntities memberEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.member, memberEntities.getMembers());
+        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.member, memberEntities.getMembers(), sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -123,10 +125,11 @@ public class MUCRoomMembersService {
     public Response addMUCRoomMember(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
             @Parameter(description = "The (bare) JID of the entity that is to be a registered member.", example = "john@example.org", required = true) @PathParam("jid") String jid,
-            @Parameter(description = "The name of the MUC room to which a member is to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+            @Parameter(description = "The name of the MUC room to which a member is to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+            @Parameter(description = "Whether to send invitation to the newly affiliated user.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addMember(serviceName, roomName, jid);
+        MUCRoomController.getInstance().addMember(serviceName, roomName, jid, sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -144,10 +147,11 @@ public class MUCRoomMembersService {
     public Response addMUCRoomMemberGroup(
             @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
             @Parameter(description = "The name of the user group from which all members will be registered members of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,
-            @Parameter(description = "The name of the MUC room to which members are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+            @Parameter(description = "The name of the MUC room to which members are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+            @Parameter(description = "Whether to send invitations to newly affiliated users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addMember(serviceName, roomName, groupname);
+        MUCRoomController.getInstance().addMember(serviceName, roomName, groupname, sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOutcastsService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOutcastsService.java
@@ -82,7 +82,7 @@ public class MUCRoomOutcastsService {
         @RequestBody(description = "The new list of room outcasts.", required = true) OutcastEntities outcastEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.outcast, outcastEntities.getOutcasts());
+        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.outcast, outcastEntities.getOutcasts(), false);
         return Response.status(Status.CREATED).build();
     }
 
@@ -105,7 +105,7 @@ public class MUCRoomOutcastsService {
         @RequestBody(description = "The list of room outcasts to add to the room.", required = true) OutcastEntities outcastEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.outcast, outcastEntities.getOutcasts());
+        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.outcast, outcastEntities.getOutcasts(), false);
         return Response.status(Status.CREATED).build();
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOwnersService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomOwnersService.java
@@ -78,10 +78,11 @@ public class MUCRoomOwnersService {
     public Response replaceMUCRoomOwners(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the MUC room of which owners are to be replaced.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to newly affiliated users.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations,
         @RequestBody(description = "The new list of room owners.", required = true) OwnerEntities ownerEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.owner, ownerEntities.getOwners());
+        MUCRoomController.getInstance().replaceAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.owner, ownerEntities.getOwners(), sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -101,10 +102,11 @@ public class MUCRoomOwnersService {
     public Response addMUCRoomOwners(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the MUC room to which owners are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to new owners.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations,
         @RequestBody(description = "The list of room owners to add to the room.", required = true) OwnerEntities ownerEntities)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.owner, ownerEntities.getOwners());
+        MUCRoomController.getInstance().addAffiliatedUsers(serviceName, roomName, MUCRole.Affiliation.owner, ownerEntities.getOwners(), sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -122,10 +124,11 @@ public class MUCRoomOwnersService {
     public Response addMUCRoomOwner(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The (bare) JID of the entity that is to be added as an owner.", example = "john@example.org", required = true) @PathParam("jid") String jid,
-        @Parameter(description = "The name of the MUC room to which an owner is to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+        @Parameter(description = "The name of the MUC room to which an owner is to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitation to new owner.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addOwner(serviceName, roomName, jid);
+        MUCRoomController.getInstance().addOwner(serviceName, roomName, jid, sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 
@@ -143,10 +146,11 @@ public class MUCRoomOwnersService {
     public Response addMUCRoomOwnerGroup(
         @Parameter(description = "The name of the MUC service that the MUC room is part of.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
         @Parameter(description = "The name of the user group from which all members will be owners of the room.", example = "Operators", required = true) @PathParam("groupname") String groupname,
-        @Parameter(description = "The name of the MUC room to which owners are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName)
+        @Parameter(description = "The name of the MUC room to which owners are to be added.", example = "lobby", required = true) @PathParam("roomName") String roomName,
+        @Parameter(description = "Whether to send invitations to new owners.", example = "true", required = false) @DefaultValue("false") @QueryParam("sendInvitations") boolean sendInvitations)
         throws ServiceException
     {
-        MUCRoomController.getInstance().addOwner(serviceName, roomName, groupname);
+        MUCRoomController.getInstance().addOwner(serviceName, roomName, groupname, sendInvitations);
         return Response.status(Status.CREATED).build();
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/utils/UserUtils.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/utils/UserUtils.java
@@ -52,7 +52,7 @@ public class UserUtils {
      * @return the list
      */
     public static List<UserEntity> convertUsersToUserEntities(Collection<User> users, String userSearch) {
-        List<UserEntity> result = new ArrayList<UserEntity>();
+        List<UserEntity> result = new ArrayList<>();
 
         for (User user : users) {
             if (userSearch != null) {
@@ -76,7 +76,7 @@ public class UserUtils {
     public static UserEntity convertUserToUserEntity(User user) {
         UserEntity userEntity = new UserEntity(user.getUsername(), user.getName(), user.getEmail());
 
-        List<UserProperty> userProperties = new ArrayList<UserProperty>();
+        List<UserProperty> userProperties = new ArrayList<>();
         for (Entry<String, String> property : user.getProperties().entrySet()) {
             userProperties.add(new UserProperty(property.getKey(), property.getValue()));
         }
@@ -89,7 +89,6 @@ public class UserUtils {
      * Checks if is valid sub type.
      *
      * @param subType            the sub type
-     * @return true, if is valid sub type
      * @throws UserAlreadyExistsException the user already exists exception
      */
     public static void checkSubType(int subType) throws UserAlreadyExistsException {
@@ -126,10 +125,7 @@ public class UserUtils {
         final int index = jid.indexOf('@');
         if (index == -1) {
             return false;
-        } else if (jid.indexOf('@', index + 1) != -1) {
-            return false;
-        }
-        return true;
+        } else return jid.indexOf('@', index + 1) == -1;
     }
     /**
      * Checks if this group exists.
@@ -139,10 +135,27 @@ public class UserUtils {
      */
     public static boolean isValidGroupName(String groupname) {
         try {
-            Group g = GroupManager.getInstance().getGroup(groupname);
+            GroupManager.getInstance().getGroup(groupname);
         } catch(GroupNotFoundException e) {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Checks if the JID represents a group, and returns the group if it does.
+     * @param maybeAGroupJIDOrAGroupName
+     *          A JID that may or may not be a group JID or even just a group name
+     * @return
+     *          The group represented by the JID, or null if the JID does not represent a group
+     */
+    public static Group getGroupIfIsGroup(JID maybeAGroupJIDOrAGroupName) {
+        try {
+            return GroupManager.getInstance().getGroup(maybeAGroupJIDOrAGroupName);
+        } catch (GroupNotFoundException e) {
+            // Just return null
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR adds functionality for sending invitations to users and groups. In two distinct ways: whenever a mutation is performed that causes new affiliations to exist, and explicitly by calling a specialised endpoint to send invitation messages.

Sending invitations is always optional, and the default is to not send any invitations.

Fixes #128.
Fixes #129.