### PR TITLE
fixes #136: Implement group role handling when creating/updating a room

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ REST API Plugin Changelog
 <p><b>1.9.0</b> (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/141'>#141</a>] - Remove boilerplate code for managing MUC room affiliations</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/136'>#136</a>] - Implement group role handling when creating/updating a room</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/130'>#130</a>] - Add endpoint to create a new MUC service</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/129'>#129</a>] - Add endpoint(s) to invite users to a chatroom</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/128'>#128</a>] - Modify endpoints to add 'send invitations to affiliated users' as optional functionality</li>


### PR DESCRIPTION
Prior to this commit, affiliation-groups (memberGroups, adminGroups, ownerGroups and outcastGroups) that were present in MUC room entities used to create up update a MUC room, were ignored.