### PR TITLE
fixes #146: Limit URI template match for MUC affiliation

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.9.1</b> (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/146'>#146</a>] - Chatroom 'affiliation' URL template clash</li>
+</ul>
+
 <p><b>1.9.0</b> August 4, 2022</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/141'>#141</a>] - Remove boilerplate code for managing MUC room affiliations</li>

--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ REST API Plugin Changelog
 
 <p><b>1.9.1</b> (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/148'>#148</a>] - Example of MUC invite contains escaped characters</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/146'>#146</a>] - Chatroom 'affiliation' URL template clash</li>
 </ul>
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -550,18 +550,18 @@ public class MUCRoomController {
      *            the service name
      * @param roomName
      *            the room name
-     * @param mucInvitationEntity
+     * @param mucInvitationsEntity
      *            the invitation entity containing invitation reason and jids to invite
      * @throws ServiceException
      *             the service exception
      */
-    public void inviteUsersAndOrGroups(String serviceName, String roomName, MUCInvitationEntity mucInvitationEntity)
+    public void inviteUsersAndOrGroups(String serviceName, String roomName, MUCInvitationsEntity mucInvitationsEntity)
             throws ServiceException {
         MUCRoom room = getRoom(serviceName, roomName);
 
         // First determine where to send all the invitations
         Set<JID> targetJIDs = new HashSet<>();
-        for (String jidString : mucInvitationEntity.getJidsToInvite()) {
+        for (String jidString : mucInvitationsEntity.getJidsToInvite()) {
             JID jid = UserUtils.checkAndGetJID(jidString);
             // Is it a group? Then unpack and send to every single group member.
             Group g = UserUtils.getGroupIfIsGroup(jid);
@@ -575,7 +575,7 @@ public class MUCRoomController {
         // And now send
         for (JID jid : targetJIDs) {
             try {
-                room.sendInvitation(jid, mucInvitationEntity.getReason(), room.getRole(), null);
+                room.sendInvitation(jid, mucInvitationsEntity.getReason(), room.getRole(), null);
             } catch (ForbiddenException | CannotBeInvitedException e) {
                 throw new ServiceException("Could not invite user", jid.toString(), ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN, e);
             }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationEntity.java
@@ -16,21 +16,15 @@
 
 package org.jivesoftware.openfire.plugin.rest.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.ArrayList;
-import java.util.List;
 
 @XmlRootElement(name = "mucInvitation")
 public class MUCInvitationEntity {
 
     String reason;
-
-    private List<String> jidsToInvite;
 
     public MUCInvitationEntity() {
     }
@@ -43,20 +37,5 @@ public class MUCInvitationEntity {
 
     public void setReason(String reason) {
         this.reason = reason;
-    }
-
-    @XmlElementWrapper(name = "jidsToInvite")
-    @XmlElement(name = "jid")
-    @JsonProperty(value = "jidsToInvite")
-    @Schema(description = "The JIDs and/or names of the users and groups to invite into the room", example = "<jidsToInvite><jid>jane@example.org</jid></jidsToInvite>")
-    public List<String> getJidsToInvite() {
-        if (jidsToInvite == null) {
-            jidsToInvite = new ArrayList<>();
-        }
-        return jidsToInvite;
-    }
-
-    public void setJidsToInvite(List<String> jidsToInvite) {
-        this.jidsToInvite = jidsToInvite;
     }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationsEntity.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationsEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.plugin.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement(name = "mucInvitations")
+public class MUCInvitationsEntity extends MUCInvitationEntity
+{
+    public MUCInvitationsEntity() {
+        super();
+    }
+    
+    private List<String> jidsToInvite;
+
+    @XmlElementWrapper(name = "jidsToInvite")
+    @XmlElement(name = "jid")
+    @JsonProperty(value = "jidsToInvite")
+    @Schema(description = "The JIDs and/or names of the users and groups to invite into the room")
+    public List<String> getJidsToInvite() {
+        if (jidsToInvite == null) {
+            jidsToInvite = new ArrayList<>();
+        }
+        return jidsToInvite;
+    }
+
+    public void setJidsToInvite(List<String> jidsToInvite) {
+        this.jidsToInvite = jidsToInvite;
+    }
+
+}

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAffiliationsService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomAffiliationsService.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Response.Status;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Path("restapi/v1/chatrooms/{roomName}/{affiliation}")
+@Path("restapi/v1/chatrooms/{roomName}/{affiliation: (admins|members|outcasts|owners)}")
 @Tag(name = "Chat room", description = "Managing Multi-User chat rooms.")
 public class MUCRoomAffiliationsService
 {

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomService.java
@@ -240,10 +240,12 @@ public class MUCRoomService {
             @RequestBody(description = "The invitation message to send and whom to send it to.", required = true) MUCInvitationEntity mucInvitationEntity)
         throws ServiceException
     {
-        if (!mucInvitationEntity.getJidsToInvite().contains(jid)) {
-            mucInvitationEntity.getJidsToInvite().add(jid);
+        final MUCInvitationsEntity multiple = new MUCInvitationsEntity();
+        multiple.setReason(mucInvitationEntity.getReason());
+        if (!multiple.getJidsToInvite().contains(jid)) {
+            multiple.getJidsToInvite().add(jid);
         }
-        MUCRoomController.getInstance().inviteUsersAndOrGroups(serviceName, roomName, mucInvitationEntity);
+        MUCRoomController.getInstance().inviteUsersAndOrGroups(serviceName, roomName, multiple);
         return Response.status(Status.OK).build();
     }
 
@@ -262,10 +264,10 @@ public class MUCRoomService {
     public Response inviteUsersAndOrGroupsToMUCRoom(
         @Parameter(description = "The name of the chat room in which to invite a user or group", example = "lobby", required = true) @PathParam("roomName") String roomName,
         @Parameter(description = "The name of the chat room's MUC service.", example = "conference", required = false) @DefaultValue("conference") @QueryParam("servicename") String serviceName,
-        @RequestBody(description = "The invitation message to send and whom to send it to.", required = true) MUCInvitationEntity mucInvitationEntity)
+        @RequestBody(description = "The invitation message to send and whom to send it to.", required = true) MUCInvitationsEntity mucInvitationsEntity)
         throws ServiceException
     {
-        MUCRoomController.getInstance().inviteUsersAndOrGroups(serviceName, roomName, mucInvitationEntity);
+        MUCRoomController.getInstance().inviteUsersAndOrGroups(serviceName, roomName, mucInvitationsEntity);
         return Response.status(Status.OK).build();
     }
 


### PR DESCRIPTION
The fix for issue #141 introduces a template to replace four distinct URL patterns:
- `/restapi/v1/chatrooms/{roomName}/owners`
- `/restapi/v1/chatrooms/{roomName}/admins`
- `/restapi/v1/chatrooms/{roomName}/members`
- `/restapi/v1/chatrooms/{roomName}/outcasts`

got replaced by

- `/restapi/v1/chatrooms/{roomName}/{affiliation}`

Sadly, this template matches more than just those four. URLs like these also get caught, making them misbehave:

- `/restapi/v1/chatrooms/{roomName}/chathistory`
- `/restapi/v1/chatrooms/{roomName}/occupants`
- `/restapi/v1/chatrooms/{roomName}/participants`
- `/restapi/v1/chatrooms/{roomName}/invite`

This commit fixes the problem by applying a regular expression to the `{affiliation}` template, requiring it to match one of four distinct options.

Also introduces a fix for #148 by introducing a distinct new entity used to post data, rather than re-use an existing one that got an additional, optional parameter.