### PR TITLE
fixes #159: Ensure that a JID can be affiliated only once

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.10.1</b> (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/159'>#159</a>] - Fix issues with duplicated MUC room affiliations</li>
+</ul>
+
 <p><b>1.10.0</b> September 29, 2022</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/155'>#155</a>] - Add statistics for endpoint responses</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2022-09-29</date>
+    <date>2022-11-01</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">


### PR DESCRIPTION
Issues pop up when an attempt is ade to affiliate a JID more than once, especially when that JID is also an owner. Affiliating such a JID as something else will remove the ownership affiliation. This can trigger an issue where the room has no owners.

This commit introduces a check to verify that the inbound request does not define multiple affiliations for the same JID. It also reworks the way in which affiliations are applied.