### PR TITLE
Release 1.10.1

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,7 +44,7 @@
 REST API Plugin Changelog
 </h1>
 
-<p><b>1.10.1</b> (tbd)</p>
+<p><b>1.10.1</b> November 9, 2022</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/159'>#159</a>] - Fix issues with duplicated MUC room affiliations</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2022-11-01</date>
+    <date>2022-11-09</date>
     <minServerVersion>4.7.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.10.1-SNAPSHOT</version>
+    <version>1.10.1</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.10.1</version>
+    <version>1.10.2-SNAPSHOT</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     <licenses>


### PR DESCRIPTION
Do not squash commits, as the first commit needs to be tagged as the release.