### PR TITLE
Fixed dependencies errors for Openfire 4.8.1

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,10 +44,13 @@
 REST API Plugin Changelog
 </h1>
 
-<p><b>1.10.3</b> (tbd)</p>
+<p><b>1.11.0</b> (tbd)</p>
 <ul>
+    <li>Now requires Openfire 4.8.0 or later</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/188'>#188</a>] - Fix issues with MUC room data consistency in an Openfire cluster</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/190'>#190</a>] - Readiness and liveness probes (broken since openfire 4.8.0)</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/192'>#192</a>] - Fix issue to support swagger updating user entity</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-restAPI-plugin/issues/195'>#195</a>] - Fix API incompatibilities with Openfire 4.8.0</li>
 </ul>
 
 <p><b>1.10.2</b> November 20, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,8 +6,8 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>2023-12-22</date>
-    <minServerVersion>4.7.0</minServerVersion>
+    <date>2024-06-25</date>
+    <minServerVersion>4.8.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.8.1</version>
+        <version>4.8.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.10.3-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <name>REST API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0</version>
+        <version>4.8.1</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/GroupController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/GroupController.java
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupAlreadyExistsException;
 import org.jivesoftware.openfire.group.GroupManager;
+import org.jivesoftware.openfire.group.GroupNameInvalidException;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
 import org.jivesoftware.openfire.plugin.rest.entity.GroupEntity;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
@@ -143,7 +144,7 @@ public class GroupController {
                     // Unsure if #addAll works for the specific Collection subclass that is used in the Group implementation. Let's add them one-by-one to be safe.
                     admins.add(newAdmin);
                 }
-            } catch (GroupAlreadyExistsException e) {
+            } catch (GroupAlreadyExistsException | GroupNameInvalidException e) {
                 throw new ServiceException("Could not create a group", groupEntity.getName(),
                         ExceptionType.GROUP_ALREADY_EXISTS, Response.Status.CONFLICT, e);
             }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/JustMarriedController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/JustMarriedController.java
@@ -237,7 +237,7 @@ public class JustMarriedController {
 
         // Is this user registered with our OF server?
         String username = otherItem.getJid().getNode();
-        if (username != null && username.length() > 0 && userManager.isRegisteredUser(username)
+        if (username != null && username.length() > 0 && userManager.isRegisteredUser(otherItem.getJid(), true)
                 && XMPPServer.getInstance().isLocal(XMPPServer.getInstance().createJID(currentUser, null))) {
             try {
                 User otherUser = userManager.getUser(username);

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/JustMarriedController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/JustMarriedController.java
@@ -237,7 +237,7 @@ public class JustMarriedController {
 
         // Is this user registered with our OF server?
         String username = otherItem.getJid().getNode();
-        if (username != null && username.length() > 0 && userManager.isRegisteredUser(otherItem.getJid(), true)
+        if (username != null && username.length() > 0 && userManager.isRegisteredUser(otherItem.getJid(), false)
                 && XMPPServer.getInstance().isLocal(XMPPServer.getInstance().createJID(currentUser, null))) {
             try {
                 User otherUser = userManager.getUser(username);

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
@@ -254,7 +254,7 @@ public class SystemController {
                 // If the listener is disabled, the check to see if it is 'ready' should pass.
                 // If the check does not pass when a listener is disabled, then this test will always indicate that the
                 // server isn't ready to be used.
-                return !listener.isEnabled() || listener.getSocketAcceptor() != null;
+                return !listener.isEnabled() || listener.getConnectionAcceptor() != null;
         }
     }
     /**

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
@@ -36,6 +36,8 @@ import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 /**
@@ -44,6 +46,7 @@ import org.xmpp.packet.JID;
  * @author Justin Hunt
  */
 public class UserServiceLegacyController {
+    private static final Logger LOG = LoggerFactory.getLogger(UserServiceLegacyController.class);
     
     /** The Constant INSTANCE. */
     public static final UserServiceLegacyController INSTANCE = new UserServiceLegacyController();
@@ -107,15 +110,15 @@ public class UserServiceLegacyController {
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
                     try {
-                    group = GroupManager.getInstance().createGroup(groupName);
-                    group.getProperties().put("sharedRoster.showInRoster", "nobody");
-                    group.getProperties().put("sharedRoster.displayName", groupName);
-                    group.getProperties().put("sharedRoster.groupList", "");
+                        group = GroupManager.getInstance().createGroup(groupName);                
+                        group.getProperties().put("sharedRoster.showInRoster", "nobody");
+                        group.getProperties().put("sharedRoster.displayName", groupName);
+                        group.getProperties().put("sharedRoster.groupList", "");
                     } catch (GroupAlreadyExistsException e1) {
-						e1.printStackTrace();
-					} catch (GroupNameInvalidException e1) {
-						e1.printStackTrace();
-					}
+                        LOG.error(e1.getMessage(), e1);
+                    } catch (GroupNameInvalidException e1) {
+                        LOG.error(e1.getMessage(), e1);
+                    }
                 }
                 groups.add(group);
             }
@@ -195,15 +198,15 @@ public class UserServiceLegacyController {
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
                     try {
-                    group = GroupManager.getInstance().createGroup(groupName);
-                    group.getProperties().put("sharedRoster.showInRoster", "nobody");
-                    group.getProperties().put("sharedRoster.displayName", groupName);
-                    group.getProperties().put("sharedRoster.groupList", "");
+                        group = GroupManager.getInstance().createGroup(groupName);
+                        group.getProperties().put("sharedRoster.showInRoster", "nobody");
+                        group.getProperties().put("sharedRoster.displayName", groupName);
+                        group.getProperties().put("sharedRoster.groupList", "");
                     } catch (GroupAlreadyExistsException e1) {
-						e1.printStackTrace();
-					} catch (GroupNameInvalidException e1) {
-						e1.printStackTrace();
-					}
+                        LOG.error(e1.getMessage(), e1);
+                    } catch (GroupNameInvalidException e1) {
+                        LOG.error(e1.getMessage(), e1);
+                    }
                 }
 
                 newGroups.add(group);

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
@@ -26,6 +26,7 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupAlreadyExistsException;
 import org.jivesoftware.openfire.group.GroupManager;
+import org.jivesoftware.openfire.group.GroupNameInvalidException;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
 import org.jivesoftware.openfire.lockout.LockOutManager;
 import org.jivesoftware.openfire.roster.Roster;
@@ -105,10 +106,16 @@ public class UserServiceLegacyController {
                     group = GroupManager.getInstance().getGroup(groupName);
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
+                    try {
                     group = GroupManager.getInstance().createGroup(groupName);
                     group.getProperties().put("sharedRoster.showInRoster", "nobody");
                     group.getProperties().put("sharedRoster.displayName", groupName);
                     group.getProperties().put("sharedRoster.groupList", "");
+                    } catch (GroupAlreadyExistsException e1) {
+						e1.printStackTrace();
+					} catch (GroupNameInvalidException e1) {
+						e1.printStackTrace();
+					}
                 }
                 groups.add(group);
             }
@@ -187,10 +194,16 @@ public class UserServiceLegacyController {
                     group = GroupManager.getInstance().getGroup(groupName);
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
+                    try {
                     group = GroupManager.getInstance().createGroup(groupName);
                     group.getProperties().put("sharedRoster.showInRoster", "nobody");
                     group.getProperties().put("sharedRoster.displayName", groupName);
                     group.getProperties().put("sharedRoster.groupList", "");
+                    } catch (GroupAlreadyExistsException e1) {
+						e1.printStackTrace();
+					} catch (GroupNameInvalidException e1) {
+						e1.printStackTrace();
+					}
                 }
 
                 newGroups.add(group);

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceLegacyController.java
@@ -36,8 +36,6 @@ import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 /**
@@ -46,8 +44,7 @@ import org.xmpp.packet.JID;
  * @author Justin Hunt
  */
 public class UserServiceLegacyController {
-    private static final Logger LOG = LoggerFactory.getLogger(UserServiceLegacyController.class);
-    
+
     /** The Constant INSTANCE. */
     public static final UserServiceLegacyController INSTANCE = new UserServiceLegacyController();
     
@@ -92,8 +89,9 @@ public class UserServiceLegacyController {
      * @throws GroupNotFoundException the group not found exception
      */
     public void createUser(String username, String password, String name, String email, String groupNames)
-            throws UserAlreadyExistsException, GroupAlreadyExistsException, UserNotFoundException,
-            GroupNotFoundException {
+        throws UserAlreadyExistsException, GroupAlreadyExistsException, UserNotFoundException,
+        GroupNotFoundException, GroupNameInvalidException
+    {
         userManager.createUser(username, password, name, email);
         userManager.getUser(username);
 
@@ -109,16 +107,10 @@ public class UserServiceLegacyController {
                     group = GroupManager.getInstance().getGroup(groupName);
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
-                    try {
-                        group = GroupManager.getInstance().createGroup(groupName);                
-                        group.getProperties().put("sharedRoster.showInRoster", "nobody");
-                        group.getProperties().put("sharedRoster.displayName", groupName);
-                        group.getProperties().put("sharedRoster.groupList", "");
-                    } catch (GroupAlreadyExistsException e1) {
-                        LOG.error(e1.getMessage(), e1);
-                    } catch (GroupNameInvalidException e1) {
-                        LOG.error(e1.getMessage(), e1);
-                    }
+                    group = GroupManager.getInstance().createGroup(groupName);
+                    group.getProperties().put("sharedRoster.showInRoster", "nobody");
+                    group.getProperties().put("sharedRoster.displayName", groupName);
+                    group.getProperties().put("sharedRoster.groupList", "");
                 }
                 groups.add(group);
             }
@@ -176,7 +168,8 @@ public class UserServiceLegacyController {
      * @throws GroupAlreadyExistsException the group already exists exception
      */
     public void updateUser(String username, String password, String name, String email, String groupNames)
-            throws UserNotFoundException, GroupAlreadyExistsException {
+        throws UserNotFoundException, GroupAlreadyExistsException, GroupNameInvalidException
+    {
         User user = getUser(username);
         if (password != null)
             user.setPassword(password);
@@ -197,16 +190,10 @@ public class UserServiceLegacyController {
                     group = GroupManager.getInstance().getGroup(groupName);
                 } catch (GroupNotFoundException e) {
                     // Create this group ;
-                    try {
-                        group = GroupManager.getInstance().createGroup(groupName);
-                        group.getProperties().put("sharedRoster.showInRoster", "nobody");
-                        group.getProperties().put("sharedRoster.displayName", groupName);
-                        group.getProperties().put("sharedRoster.groupList", "");
-                    } catch (GroupAlreadyExistsException e1) {
-                        LOG.error(e1.getMessage(), e1);
-                    } catch (GroupNameInvalidException e1) {
-                        LOG.error(e1.getMessage(), e1);
-                    }
+                    group = GroupManager.getInstance().createGroup(groupName);
+                    group.getProperties().put("sharedRoster.showInRoster", "nobody");
+                    group.getProperties().put("sharedRoster.displayName", groupName);
+                    group.getProperties().put("sharedRoster.groupList", "");
                 }
 
                 newGroups.add(group);


### PR DESCRIPTION
A couple of minor fixes to allow the Rest-API plugin to correctly work in Openfire 4.8.1.
The current version 1.10.2 is working fine with the new Openfire release, except for a method signature `org.jivesoftware.openfire.session.Session.getStatus()` that is used in 
`org.jivesoftware.openfire.plugin.rest.controller.SessionController.convertToSessionEntities(Collection<ClientSession> clientSessions):133`. (It expects the method to return an integer).
The current method usage is retrocompatible, however it is has to be built with the new Openfire sources of version 4.8.1. This of course brings some compilation problems with a couple of changes in the 4.8.1 code.
The following fixes will just allow for the plugin to work as expected without breaking things up, but are not to be considered final or extensively tested. 
For anyone that wants to build this plugin for Openfire 4.8.1 can use this pull request as a workaround.