### PR TITLE
fixes #244: Prevent REST API plugin from exposing its own configuration

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ REST API Plugin Changelog
 <p><b>1.12.1</b> (to be determined)</p>
 <ul>
     <li>[<a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/251">#251</a>] - Enable JUnit 5 tests</li>
+    <li>[<a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244">#244</a>] - Prevent REST API plugin from exposing its own configuration (including authentication) via its own endpoints</li>
     <li>[<a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/242">#242</a>] - Fix individual System Property GETs returning HTTP/404</li>
     <li>[<a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/213">#213</a>] - Improve setting a subject in a chat room</li>
     <li>[<a href="https://github.com/igniterealtime/openfire-restAPI-plugin/issues/217">#217</a>] - Add Hurl e2e tests, and CI to run them</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,6 +8,7 @@
     <version>${project.version}</version>
     <date>2025-10-02</date>
     <minServerVersion>5.0.0</minServerVersion>
+    <priorToServerVersion>5.2.0</priorToServerVersion> <!-- because of OF-3313 compatibility -->
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">

--- a/src/i18n/restapi_i18n.properties
+++ b/src/i18n/restapi_i18n.properties
@@ -1,4 +1,5 @@
 system_property.plugin.restapi.customAuthFilter=The class name of a custom authentication filter implementation.
+system_property.plugin.restapi.enabled=Enables or disables the processing of REST API service requests.
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Names of MUC rooms should be node-prepped. This, however, was not guaranteed the case in some versions of Openfire and this plugin. Earlier versions of this plugin used a case-insensitive lookup to work around this. As this should be unneeded, and is quite resource intensive, this behavior has been made configurable (disabled by default).
 system_property.plugin.restapi.muc.room-mutex.enabled=Controls if a mutual exclusion lock is used when an API interacts with a room.
 system_property.plugin.restapi.secret=The value that is used to authenticate requests when using 'shared secret' authentication.

--- a/src/i18n/restapi_i18n.properties
+++ b/src/i18n/restapi_i18n.properties
@@ -1,6 +1,7 @@
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Names of MUC rooms should be node-prepped. This, however, was not guaranteed the case in some versions of Openfire and this plugin. Earlier versions of this plugin used a case-insensitive lookup to work around this. As this should be unneeded, and is quite resource intensive, this behavior has been made configurable (disabled by default).
 system_property.plugin.restapi.muc.room-mutex.enabled=Controls if a mutual exclusion lock is used when an API interacts with a room.
 system_property.plugin.restapi.secret=The value that is used to authenticate requests when using 'shared secret' authentication.
+system_property.plugin.restapi.serviceLoggingEnabled=Enables or disables additional logging of REST API service calls.
 
 stat.restapi_responses.informational.name=REST API 1xx responses
 stat.restapi_responses.informational.desc=The amount of HTTP responses that had an 'Informational' status (a code in the 1xx range).

--- a/src/i18n/restapi_i18n.properties
+++ b/src/i18n/restapi_i18n.properties
@@ -1,3 +1,4 @@
+system_property.plugin.restapi.allowedIPs=List of IP addresses that are allowed to access the REST API services. An empty list will allow all IP addresses.
 system_property.plugin.restapi.customAuthFilter=The class name of a custom authentication filter implementation.
 system_property.plugin.restapi.enabled=Enables or disables the processing of REST API service requests.
 system_property.plugin.restapi.httpAuth=The authentication mechanism used to authenticate REST API service requests.

--- a/src/i18n/restapi_i18n.properties
+++ b/src/i18n/restapi_i18n.properties
@@ -1,5 +1,6 @@
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Names of MUC rooms should be node-prepped. This, however, was not guaranteed the case in some versions of Openfire and this plugin. Earlier versions of this plugin used a case-insensitive lookup to work around this. As this should be unneeded, and is quite resource intensive, this behavior has been made configurable (disabled by default).
 system_property.plugin.restapi.muc.room-mutex.enabled=Controls if a mutual exclusion lock is used when an API interacts with a room.
+system_property.plugin.restapi.secret=The value that is used to authenticate requests when using 'shared secret' authentication.
 
 stat.restapi_responses.informational.name=REST API 1xx responses
 stat.restapi_responses.informational.desc=The amount of HTTP responses that had an 'Informational' status (a code in the 1xx range).

--- a/src/i18n/restapi_i18n.properties
+++ b/src/i18n/restapi_i18n.properties
@@ -1,5 +1,6 @@
 system_property.plugin.restapi.customAuthFilter=The class name of a custom authentication filter implementation.
 system_property.plugin.restapi.enabled=Enables or disables the processing of REST API service requests.
+system_property.plugin.restapi.httpAuth=The authentication mechanism used to authenticate REST API service requests.
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Names of MUC rooms should be node-prepped. This, however, was not guaranteed the case in some versions of Openfire and this plugin. Earlier versions of this plugin used a case-insensitive lookup to work around this. As this should be unneeded, and is quite resource intensive, this behavior has been made configurable (disabled by default).
 system_property.plugin.restapi.muc.room-mutex.enabled=Controls if a mutual exclusion lock is used when an API interacts with a room.
 system_property.plugin.restapi.secret=The value that is used to authenticate requests when using 'shared secret' authentication.

--- a/src/i18n/restapi_i18n.properties
+++ b/src/i18n/restapi_i18n.properties
@@ -1,3 +1,4 @@
+system_property.plugin.restapi.customAuthFilter=The class name of a custom authentication filter implementation.
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Names of MUC rooms should be node-prepped. This, however, was not guaranteed the case in some versions of Openfire and this plugin. Earlier versions of this plugin used a case-insensitive lookup to work around this. As this should be unneeded, and is quite resource intensive, this behavior has been made configurable (disabled by default).
 system_property.plugin.restapi.muc.room-mutex.enabled=Controls if a mutual exclusion lock is used when an API interacts with a room.
 system_property.plugin.restapi.secret=The value that is used to authenticate requests when using 'shared secret' authentication.

--- a/src/i18n/restapi_i18n_nl.properties
+++ b/src/i18n/restapi_i18n_nl.properties
@@ -1,4 +1,5 @@
 system_property.plugin.restapi.customAuthFilter=De klassenaam van een authenticatie-filter implementatie.
+system_property.plugin.restapi.enabled=Schakelt de verwerking van REST API-serviceverzoeken in of uit.
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Namen van MUC-kamers zouden genode-prepped moeten zijn. Dit werd echter niet gegarandeerd in sommige versies van Openfire en deze plugin. Oudere versies van deze plugin gebruikten een hoofdletter-ongevoelige zoekopdracht om hier omheen te werken. Dit vergt behoorlijk wat rekenkracht en zou onnodig moeten zijn. Hierom is dit gedrag configureerbaar gemaakt (standaard-instelling: uit)
 system_property.plugin.restapi.muc.room-mutex.enabled=Bepaald of een MUC-kamer-specifieke mutex wordt gebruikt wanneer de API interacteert met een MUC-kamer.
 system_property.plugin.restapi.secret=De waarde die wordt gebruikt om verzoeken te authenticeren wanneer authenticatie met een 'gedeeld geheim' wordt gebruikt.

--- a/src/i18n/restapi_i18n_nl.properties
+++ b/src/i18n/restapi_i18n_nl.properties
@@ -1,3 +1,4 @@
+system_property.plugin.restapi.allowedIPs=Een lijst van IP-adressen die toegang hebben tot de REST API-services. Een lege lijst staat alle IP-adressen toe.
 system_property.plugin.restapi.customAuthFilter=De klassenaam van een authenticatie-filter implementatie.
 system_property.plugin.restapi.enabled=Schakelt de verwerking van REST API-serviceverzoeken in of uit.
 system_property.plugin.restapi.httpAuth=Het authenticatiemechanisme dat wordt gebruikt om REST API-serviceverzoeken te authenticeren.

--- a/src/i18n/restapi_i18n_nl.properties
+++ b/src/i18n/restapi_i18n_nl.properties
@@ -1,5 +1,6 @@
 system_property.plugin.restapi.customAuthFilter=De klassenaam van een authenticatie-filter implementatie.
 system_property.plugin.restapi.enabled=Schakelt de verwerking van REST API-serviceverzoeken in of uit.
+system_property.plugin.restapi.httpAuth=Het authenticatiemechanisme dat wordt gebruikt om REST API-serviceverzoeken te authenticeren.
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Namen van MUC-kamers zouden genode-prepped moeten zijn. Dit werd echter niet gegarandeerd in sommige versies van Openfire en deze plugin. Oudere versies van deze plugin gebruikten een hoofdletter-ongevoelige zoekopdracht om hier omheen te werken. Dit vergt behoorlijk wat rekenkracht en zou onnodig moeten zijn. Hierom is dit gedrag configureerbaar gemaakt (standaard-instelling: uit)
 system_property.plugin.restapi.muc.room-mutex.enabled=Bepaald of een MUC-kamer-specifieke mutex wordt gebruikt wanneer de API interacteert met een MUC-kamer.
 system_property.plugin.restapi.secret=De waarde die wordt gebruikt om verzoeken te authenticeren wanneer authenticatie met een 'gedeeld geheim' wordt gebruikt.

--- a/src/i18n/restapi_i18n_nl.properties
+++ b/src/i18n/restapi_i18n_nl.properties
@@ -1,6 +1,7 @@
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Namen van MUC-kamers zouden genode-prepped moeten zijn. Dit werd echter niet gegarandeerd in sommige versies van Openfire en deze plugin. Oudere versies van deze plugin gebruikten een hoofdletter-ongevoelige zoekopdracht om hier omheen te werken. Dit vergt behoorlijk wat rekenkracht en zou onnodig moeten zijn. Hierom is dit gedrag configureerbaar gemaakt (standaard-instelling: uit)
 system_property.plugin.restapi.muc.room-mutex.enabled=Bepaald of een MUC-kamer-specifieke mutex wordt gebruikt wanneer de API interacteert met een MUC-kamer.
 system_property.plugin.restapi.secret=De waarde die wordt gebruikt om verzoeken te authenticeren wanneer authenticatie met een 'gedeeld geheim' wordt gebruikt.
+system_property.plugin.restapi.serviceLoggingEnabled=Aanvullende logging van REST API-serviceaanroepen in- of uitschakelen.
 
 stat.restapi_responses.informational.name=REST API 1xx antwoorden
 stat.restapi_responses.informational.desc=Het aantal HTTP antwoorden met een 'Informational' status (een code in de 1xx reeks).

--- a/src/i18n/restapi_i18n_nl.properties
+++ b/src/i18n/restapi_i18n_nl.properties
@@ -1,3 +1,4 @@
+system_property.plugin.restapi.customAuthFilter=De klassenaam van een authenticatie-filter implementatie.
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Namen van MUC-kamers zouden genode-prepped moeten zijn. Dit werd echter niet gegarandeerd in sommige versies van Openfire en deze plugin. Oudere versies van deze plugin gebruikten een hoofdletter-ongevoelige zoekopdracht om hier omheen te werken. Dit vergt behoorlijk wat rekenkracht en zou onnodig moeten zijn. Hierom is dit gedrag configureerbaar gemaakt (standaard-instelling: uit)
 system_property.plugin.restapi.muc.room-mutex.enabled=Bepaald of een MUC-kamer-specifieke mutex wordt gebruikt wanneer de API interacteert met een MUC-kamer.
 system_property.plugin.restapi.secret=De waarde die wordt gebruikt om verzoeken te authenticeren wanneer authenticatie met een 'gedeeld geheim' wordt gebruikt.

--- a/src/i18n/restapi_i18n_nl.properties
+++ b/src/i18n/restapi_i18n_nl.properties
@@ -1,5 +1,6 @@
 system_property.plugin.restapi.muc.case-insensitive-lookup.enabled=Namen van MUC-kamers zouden genode-prepped moeten zijn. Dit werd echter niet gegarandeerd in sommige versies van Openfire en deze plugin. Oudere versies van deze plugin gebruikten een hoofdletter-ongevoelige zoekopdracht om hier omheen te werken. Dit vergt behoorlijk wat rekenkracht en zou onnodig moeten zijn. Hierom is dit gedrag configureerbaar gemaakt (standaard-instelling: uit)
 system_property.plugin.restapi.muc.room-mutex.enabled=Bepaald of een MUC-kamer-specifieke mutex wordt gebruikt wanneer de API interacteert met een MUC-kamer.
+system_property.plugin.restapi.secret=De waarde die wordt gebruikt om verzoeken te authenticeren wanneer authenticatie met een 'gedeeld geheim' wordt gebruikt.
 
 stat.restapi_responses.informational.name=REST API 1xx antwoorden
 stat.restapi_responses.informational.desc=Het aantal HTTP antwoorden met een 'Informational' status (een code in de 1xx reeks).

--- a/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
@@ -138,7 +138,7 @@ public class AuthFilter implements ContainerRequestFilter {
                 throw new WebApplicationException(Status.UNAUTHORIZED);
             }
         } else {
-            if (!auth.equals(plugin.getSecret())) {
+            if (!auth.equals(RESTServicePlugin.SECRET.getValue())) {
                 LOG.warn("Wrong secret key authorization. Provided key: " + auth);
                 throw new WebApplicationException(Status.UNAUTHORIZED);
             }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
@@ -83,7 +83,7 @@ public class AuthFilter implements ContainerRequestFilter {
             return;
         }
 
-        if (!plugin.getAllowedIPs().isEmpty()) {
+        if (!RESTServicePlugin.ALLOWED_IPS.getValue().isEmpty()) {
             // Get client's IP address
             String ipAddress = httpRequest.getHeader("x-forwarded-for");
             if (ipAddress == null) {
@@ -95,7 +95,7 @@ public class AuthFilter implements ContainerRequestFilter {
                     }
                 }
             }
-            if (!plugin.getAllowedIPs().contains(ipAddress)) {
+            if (!RESTServicePlugin.ALLOWED_IPS.getValue().contains(ipAddress)) {
                 LOG.warn("REST API rejected service for IP address: " + ipAddress);
                 throw new WebApplicationException(Status.UNAUTHORIZED);
             }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
@@ -109,7 +109,7 @@ public class AuthFilter implements ContainerRequestFilter {
         }
 
         // HTTP Basic Auth or Shared Secret key
-        if ("basic".equals(plugin.getHttpAuth())) {
+        if (RESTServicePlugin.AuthType.basic.equals(RESTServicePlugin.AUTH_TYPE.getValue())) {
             String[] usernameAndPassword = BasicAuth.decode(auth);
 
             // If username or password fail

--- a/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/AuthFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class AuthFilter implements ContainerRequestFilter {
             return;
         }
 
-        if (!plugin.isEnabled()) {
+        if (!RESTServicePlugin.ENABLED.getValue()) {
             LOG.debug("REST API Plugin is not enabled");
             throw new WebApplicationException(Status.FORBIDDEN);
         }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -21,10 +21,7 @@ import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.plugin.rest.service.JerseyWrapper;
 import org.jivesoftware.openfire.stats.StatisticsManager;
-import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.PropertyEventDispatcher;
-import org.jivesoftware.util.PropertyEventListener;
-import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.*;
 
 import java.io.File;
 import java.util.*;
@@ -34,12 +31,19 @@ import java.util.*;
  */
 public class RESTServicePlugin implements Plugin, PropertyEventListener {
 
+    /**
+     * The value that is used to authenticate requests when using 'shared secret' authentication.
+     */
+    public static final SystemProperty<String> SECRET = SystemProperty.Builder.ofType(String.class)
+        .setPlugin("REST API")
+        .setKey("plugin.restapi.secret")
+        .setDynamic(true)
+        .setEncrypted(true)
+        .build();
+
     private static final String CUSTOM_AUTH_FILTER_PROPERTY_NAME = "plugin.restapi.customAuthFilter";
     public static final String SERVICE_LOGGING_ENABLED = "plugin.restapi.serviceLoggingEnabled";
 
-    /** The secret. */
-    private String secret;
-    
     /** The allowed i ps. */
     private Collection<String> allowedIPs;
     
@@ -68,12 +72,11 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
     /* (non-Javadoc)
      * @see org.jivesoftware.openfire.container.Plugin#initializePlugin(org.jivesoftware.openfire.container.PluginManager, java.io.File)
      */
-    public void initializePlugin(PluginManager manager, File pluginDirectory) {
-        secret = JiveGlobals.getProperty("plugin.restapi.secret", "");
+    public void initializePlugin(PluginManager manager, File pluginDirectory)
+    {
         // If no secret key has been assigned, assign a random one.
-        if ("".equals(secret)) {
-            secret = StringUtils.randomString(16);
-            setSecret(secret);
+        if (SECRET.getValue() == null || SECRET.getValue().isEmpty()) {
+            SECRET.setValue(StringUtils.randomString(16));
         }
         
         // See if Custom authentication filter has been defined
@@ -134,26 +137,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      */
     public String loadAuthenticationFilter(String customAuthFilterClassName) {
         return JerseyWrapper.tryLoadingAuthenticationFilter(customAuthFilterClassName);
-    }
-    
-    /**
-     * Returns the secret key that only valid requests should know.
-     *
-     * @return the secret key.
-     */
-    public String getSecret() {
-        return secret;
-    }
-
-    /**
-     * Sets the secret key that grants permission to use the userservice.
-     *
-     * @param secret
-     *            the secret key.
-     */
-    public void setSecret(String secret) {
-        JiveGlobals.setProperty("plugin.restapi.secret", secret);
-        this.secret = secret;
     }
 
     /**
@@ -240,9 +223,7 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      * @see org.jivesoftware.util.PropertyEventListener#propertySet(java.lang.String, java.util.Map)
      */
     public void propertySet(String property, Map<String, Object> params) {
-        if (property.equals("plugin.restapi.secret")) {
-            this.secret = (String) params.get("value");
-        } else if (property.equals("plugin.restapi.enabled")) {
+        if (property.equals("plugin.restapi.enabled")) {
             this.enabled = Boolean.parseBoolean((String) params.get("value"));
         } else if (property.equals("plugin.restapi.allowedIPs")) {
             this.allowedIPs = StringUtils.stringToCollection((String) params.get("value"));
@@ -257,9 +238,7 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      * @see org.jivesoftware.util.PropertyEventListener#propertyDeleted(java.lang.String, java.util.Map)
      */
     public void propertyDeleted(String property, Map<String, Object> params) {
-        if (property.equals("plugin.restapi.secret")) {
-            this.secret = "";
-        } else if (property.equals("plugin.restapi.enabled")) {
+        if (property.equals("plugin.restapi.enabled")) {
             this.enabled = false;
         } else if (property.equals("plugin.restapi.allowedIPs")) {
             this.allowedIPs = Collections.emptyList();

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -29,7 +29,7 @@ import java.util.*;
 /**
  * The Class RESTServicePlugin.
  */
-public class RESTServicePlugin implements Plugin, PropertyEventListener {
+public class RESTServicePlugin implements Plugin {
 
     /**
      * The value that is used to authenticate requests when using 'shared secret' authentication.
@@ -129,9 +129,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             registeredStatisticKeys.add(statistic.getKeyName());
         }
 
-        // Listen to system property events
-        PropertyEventDispatcher.addListener(this);
-
         // Exclude this servlet from requering the user to login
         AuthCheckFilter.addExclude(JerseyWrapper.SERVLET_URL);
     }
@@ -149,8 +146,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
 
         // Release the excluded URL
         AuthCheckFilter.removeExclude(JerseyWrapper.SERVLET_URL);
-        // Stop listening to system property events
-        PropertyEventDispatcher.removeListener(this);
     }
 
     /**
@@ -167,31 +162,5 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      */
     public String loadAuthenticationFilter(String customAuthFilterClassName) {
         return JerseyWrapper.tryLoadingAuthenticationFilter(customAuthFilterClassName);
-    }
-
-    /* (non-Javadoc)
-     * @see org.jivesoftware.util.PropertyEventListener#propertySet(java.lang.String, java.util.Map)
-     */
-    public void propertySet(String property, Map<String, Object> params) {
-    }
-
-    /* (non-Javadoc)
-     * @see org.jivesoftware.util.PropertyEventListener#propertyDeleted(java.lang.String, java.util.Map)
-     */
-    public void propertyDeleted(String property, Map<String, Object> params) {
-    }
-
-    /* (non-Javadoc)
-     * @see org.jivesoftware.util.PropertyEventListener#xmlPropertySet(java.lang.String, java.util.Map)
-     */
-    public void xmlPropertySet(String property, Map<String, Object> params) {
-        // Do nothing
-    }
-
-    /* (non-Javadoc)
-     * @see org.jivesoftware.util.PropertyEventListener#xmlPropertyDeleted(java.lang.String, java.util.Map)
-     */
-    public void xmlPropertyDeleted(String property, Map<String, Object> params) {
-        // Do nothing
     }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -70,11 +70,39 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         .setDefaultValue(false)
         .build();
 
+    /**
+     * The authentication mechanism used to authenticate REST API service requests.
+     */
+    public static final SystemProperty<AuthType> AUTH_TYPE = SystemProperty.Builder.ofType(AuthType.class)
+        .setPlugin("REST API")
+        .setKey("plugin.restapi.httpAuth")
+        .setDynamic(true)
+        .setDefaultValue(AuthType.basic)
+        .build();
+
+    /**
+     * The types of authentication mechanisms for REST service calls.
+     */
+    public enum AuthType
+    {
+        /**
+         * Use HTTP Basic Authentication.
+         */
+        basic,
+
+        /**
+         * Use a Shared Secret.
+         */
+        secret,
+
+        /**
+         * Use a custom authentication implementation.
+         */
+        custom
+    }
+
     /** The allowed i ps. */
     private Collection<String> allowedIPs;
-
-    /** The http auth. */
-    private String httpAuth;
     
     private final Set<String> registeredStatisticKeys = new HashSet<>();
 
@@ -93,9 +121,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             StatisticsManager.getInstance().addStatistic(statistic.getKeyName(), statistic);
             registeredStatisticKeys.add(statistic.getKeyName());
         }
-
-        // See if the HTTP Basic Auth is enabled or not.
-        httpAuth = JiveGlobals.getProperty("plugin.restapi.httpAuth", "basic");
 
         // Get the list of IP addresses that can use this service. An empty list
         // means that this filter is disabled.
@@ -160,33 +185,12 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         this.allowedIPs = allowedIPs;
     }
 
-    /**
-     * Gets the http authentication mechanism.
-     *
-     * @return the http authentication mechanism
-     */
-    public String getHttpAuth() {
-        return httpAuth;
-    }
-
-    /**
-     * Sets the http auth.
-     *
-     * @param httpAuth the new http auth
-     */
-    public void setHttpAuth(String httpAuth) {
-        this.httpAuth = httpAuth;
-        JiveGlobals.setProperty("plugin.restapi.httpAuth", httpAuth);
-    }
-
     /* (non-Javadoc)
      * @see org.jivesoftware.util.PropertyEventListener#propertySet(java.lang.String, java.util.Map)
      */
     public void propertySet(String property, Map<String, Object> params) {
         if (property.equals("plugin.restapi.allowedIPs")) {
             this.allowedIPs = StringUtils.stringToCollection((String) params.get("value"));
-        } else if (property.equals("plugin.restapi.httpAuth")) {
-            this.httpAuth = (String) params.get("value");
         }
     }
 
@@ -196,8 +200,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
     public void propertyDeleted(String property, Map<String, Object> params) {
         if (property.equals("plugin.restapi.allowedIPs")) {
             this.allowedIPs = Collections.emptyList();
-        } else if (property.equals("plugin.restapi.httpAuth")) {
-            this.httpAuth = "basic";
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,25 +41,23 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         .setEncrypted(true)
         .build();
 
+    /**
+     * Enables or disables additional logging of REST API service calls.
+     */
+    public static final SystemProperty<Boolean> SERVICE_LOGGING_ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setPlugin("REST API")
+        .setKey("plugin.restapi.serviceLoggingEnabled")
+        .setDynamic(true)
+        .setDefaultValue(false)
+        .build();
+
     private static final String CUSTOM_AUTH_FILTER_PROPERTY_NAME = "plugin.restapi.customAuthFilter";
-    public static final String SERVICE_LOGGING_ENABLED = "plugin.restapi.serviceLoggingEnabled";
 
     /** The allowed i ps. */
     private Collection<String> allowedIPs;
     
     /** The enabled. */
     private boolean enabled;
-
-    public boolean isServiceLoggingEnabled() {
-        return serviceLoggingEnabled;
-    }
-
-    public void setServiceLoggingEnabled(boolean serviceLoggingEnabled) {
-        JiveGlobals.setProperty(SERVICE_LOGGING_ENABLED, Boolean.toString(serviceLoggingEnabled));
-        this.serviceLoggingEnabled = serviceLoggingEnabled;
-    }
-
-    private boolean serviceLoggingEnabled;
 
     /** The http auth. */
     private String httpAuth;
@@ -98,7 +96,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         // means that this filter is disabled.
         allowedIPs = StringUtils.stringToCollection(JiveGlobals.getProperty("plugin.restapi.allowedIPs", ""));
 
-        setServiceLoggingEnabled(JiveGlobals.getBooleanProperty(SERVICE_LOGGING_ENABLED, false));
         // Listen to system property events
         PropertyEventDispatcher.addListener(this);
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -81,6 +81,16 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         .build();
 
     /**
+     * List of IP addresses that are allowed to access the REST API services.
+     */
+    public static final SystemProperty<Set<String>> ALLOWED_IPS = SystemProperty.Builder.ofType(Set.class)
+        .setPlugin("REST API")
+        .setKey("plugin.restapi.allowedIPs")
+        .setDefaultValue(Collections.emptySet())
+        .setDynamic(true)
+        .buildSet(String.class);
+
+    /**
      * The types of authentication mechanisms for REST service calls.
      */
     public enum AuthType
@@ -100,9 +110,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
          */
         custom
     }
-
-    /** The allowed i ps. */
-    private Collection<String> allowedIPs;
     
     private final Set<String> registeredStatisticKeys = new HashSet<>();
 
@@ -121,10 +128,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             StatisticsManager.getInstance().addStatistic(statistic.getKeyName(), statistic);
             registeredStatisticKeys.add(statistic.getKeyName());
         }
-
-        // Get the list of IP addresses that can use this service. An empty list
-        // means that this filter is disabled.
-        allowedIPs = StringUtils.stringToCollection(JiveGlobals.getProperty("plugin.restapi.allowedIPs", ""));
 
         // Listen to system property events
         PropertyEventDispatcher.addListener(this);
@@ -165,42 +168,17 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
     public String loadAuthenticationFilter(String customAuthFilterClassName) {
         return JerseyWrapper.tryLoadingAuthenticationFilter(customAuthFilterClassName);
     }
-    
-    /**
-     * Gets the allowed i ps.
-     *
-     * @return the allowed i ps
-     */
-    public Collection<String> getAllowedIPs() {
-        return allowedIPs;
-    }
-
-    /**
-     * Sets the allowed i ps.
-     *
-     * @param allowedIPs the new allowed i ps
-     */
-    public void setAllowedIPs(Collection<String> allowedIPs) {
-        JiveGlobals.setProperty("plugin.restapi.allowedIPs", StringUtils.collectionToString(allowedIPs));
-        this.allowedIPs = allowedIPs;
-    }
 
     /* (non-Javadoc)
      * @see org.jivesoftware.util.PropertyEventListener#propertySet(java.lang.String, java.util.Map)
      */
     public void propertySet(String property, Map<String, Object> params) {
-        if (property.equals("plugin.restapi.allowedIPs")) {
-            this.allowedIPs = StringUtils.stringToCollection((String) params.get("value"));
-        }
     }
 
     /* (non-Javadoc)
      * @see org.jivesoftware.util.PropertyEventListener#propertyDeleted(java.lang.String, java.util.Map)
      */
     public void propertyDeleted(String property, Map<String, Object> params) {
-        if (property.equals("plugin.restapi.allowedIPs")) {
-            this.allowedIPs = Collections.emptyList();
-        }
     }
 
     /* (non-Javadoc)

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -60,11 +60,18 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         .setDynamic(true)
         .build();
 
+    /**
+     * Enables or disables the processing of REST API service requests.
+     */
+    public static final SystemProperty<Boolean> ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setPlugin("REST API")
+        .setKey("plugin.restapi.enabled")
+        .setDynamic(true)
+        .setDefaultValue(false)
+        .build();
+
     /** The allowed i ps. */
     private Collection<String> allowedIPs;
-    
-    /** The enabled. */
-    private boolean enabled;
 
     /** The http auth. */
     private String httpAuth;
@@ -86,9 +93,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             StatisticsManager.getInstance().addStatistic(statistic.getKeyName(), statistic);
             registeredStatisticKeys.add(statistic.getKeyName());
         }
-
-        // See if the service is enabled or not.
-        enabled = JiveGlobals.getBooleanProperty("plugin.restapi.enabled", false);
 
         // See if the HTTP Basic Auth is enabled or not.
         httpAuth = JiveGlobals.getProperty("plugin.restapi.httpAuth", "basic");
@@ -157,28 +161,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
     }
 
     /**
-     * Returns true if the user service is enabled. If not enabled, it will not
-     * accept requests to create new accounts.
-     *
-     * @return true if the user service is enabled.
-     */
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    /**
-     * Enables or disables the user service. If not enabled, it will not accept
-     * requests to create new accounts.
-     *
-     * @param enabled
-     *            true if the user service should be enabled.
-     */
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        JiveGlobals.setProperty("plugin.restapi.enabled", enabled ? "true" : "false");
-    }
-
-    /**
      * Gets the http authentication mechanism.
      *
      * @return the http authentication mechanism
@@ -201,9 +183,7 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      * @see org.jivesoftware.util.PropertyEventListener#propertySet(java.lang.String, java.util.Map)
      */
     public void propertySet(String property, Map<String, Object> params) {
-        if (property.equals("plugin.restapi.enabled")) {
-            this.enabled = Boolean.parseBoolean((String) params.get("value"));
-        } else if (property.equals("plugin.restapi.allowedIPs")) {
+        if (property.equals("plugin.restapi.allowedIPs")) {
             this.allowedIPs = StringUtils.stringToCollection((String) params.get("value"));
         } else if (property.equals("plugin.restapi.httpAuth")) {
             this.httpAuth = (String) params.get("value");
@@ -214,9 +194,7 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      * @see org.jivesoftware.util.PropertyEventListener#propertyDeleted(java.lang.String, java.util.Map)
      */
     public void propertyDeleted(String property, Map<String, Object> params) {
-        if (property.equals("plugin.restapi.enabled")) {
-            this.enabled = false;
-        } else if (property.equals("plugin.restapi.allowedIPs")) {
+        if (property.equals("plugin.restapi.allowedIPs")) {
             this.allowedIPs = Collections.emptyList();
         } else if (property.equals("plugin.restapi.httpAuth")) {
             this.httpAuth = "basic";

--- a/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/RESTServicePlugin.java
@@ -51,7 +51,14 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
         .setDefaultValue(false)
         .build();
 
-    private static final String CUSTOM_AUTH_FILTER_PROPERTY_NAME = "plugin.restapi.customAuthFilter";
+    /**
+     * The class name of a custom authentication filter implementation.
+     */
+    public static final SystemProperty<String> CUSTOM_AUTH_FILTER = SystemProperty.Builder.ofType(String.class)
+        .setPlugin("REST API")
+        .setKey("plugin.restapi.customAuthFilter")
+        .setDynamic(true)
+        .build();
 
     /** The allowed i ps. */
     private Collection<String> allowedIPs;
@@ -62,9 +69,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
     /** The http auth. */
     private String httpAuth;
     
-    /** The custom authentication filter */
-    private String customAuthFilterClassName;
-
     private final Set<String> registeredStatisticKeys = new HashSet<>();
 
     /* (non-Javadoc)
@@ -77,9 +81,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             SECRET.setValue(StringUtils.randomString(16));
         }
         
-        // See if Custom authentication filter has been defined
-        customAuthFilterClassName = JiveGlobals.getProperty("plugin.restapi.customAuthFilter", "");
-
         // Start collecting statistics.
         for (StatisticsFilter.RestResponseFamilyStatistic statistic : StatisticsFilter.generateAllFamilyStatisticInstances()) {
             StatisticsManager.getInstance().addStatistic(statistic.getKeyName(), statistic);
@@ -134,26 +135,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
      */
     public String loadAuthenticationFilter(String customAuthFilterClassName) {
         return JerseyWrapper.tryLoadingAuthenticationFilter(customAuthFilterClassName);
-    }
-
-    /**
-     * Returns the custom authentication filter class name used in place of the basic ones to grant permission to use the Rest services.
-     *
-     * @return custom authentication filter class name .
-     */
-    public String getCustomAuthFilterClassName() {
-        return customAuthFilterClassName;
-    }
-
-    /**
-     * Sets the customAuthFIlterClassName used to grant permission to use the Rest services.
-     *
-     * @param customAuthFilterClassName
-     *            custom authentication filter class name.
-     */
-    public void setCustomAuthFiIterClassName(String customAuthFilterClassName) {
-        JiveGlobals.setProperty(CUSTOM_AUTH_FILTER_PROPERTY_NAME, customAuthFilterClassName);
-        this.customAuthFilterClassName = customAuthFilterClassName;
     }
     
     /**
@@ -226,8 +207,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             this.allowedIPs = StringUtils.stringToCollection((String) params.get("value"));
         } else if (property.equals("plugin.restapi.httpAuth")) {
             this.httpAuth = (String) params.get("value");
-        } else if(property.equals(CUSTOM_AUTH_FILTER_PROPERTY_NAME)) {
-            this.customAuthFilterClassName = (String) params.get("value");
         }
     }
 
@@ -241,8 +220,6 @@ public class RESTServicePlugin implements Plugin, PropertyEventListener {
             this.allowedIPs = Collections.emptyList();
         } else if (property.equals("plugin.restapi.httpAuth")) {
             this.httpAuth = "basic";
-        } else if(property.equals(CUSTOM_AUTH_FILTER_PROPERTY_NAME)) {
-            this.customAuthFilterClassName = null;
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/ClusteringController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/ClusteringController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (c) 2022-2026 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
 import org.jivesoftware.openfire.plugin.rest.entity.ClusterNodeEntities;
 import org.jivesoftware.openfire.plugin.rest.entity.ClusterNodeEntity;
-import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +56,7 @@ public class ClusteringController {
     }
 
     public static void log(String logMessage) {
-        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+        if (RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue()) {
             LOG.info(logMessage);
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Ignite Realtime Foundation
+ * Copyright (c) 2022-2026 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.plugin.rest.utils.MUCRoomUtils;
 import org.jivesoftware.openfire.plugin.rest.utils.UserUtils;
 import org.jivesoftware.util.AlreadyExistsException;
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
@@ -102,13 +101,13 @@ public class MUCRoomController {
     }
 
     public static void log(String logMessage) {
-        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+        if (RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue()) {
             LOG.info(logMessage);
         }
     }
 
     public static void log(String logMessage, Throwable t) {
-        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+        if (RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue()) {
             LOG.info(logMessage, t);
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCServiceController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCServiceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (c) 2022-2026 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.jivesoftware.openfire.plugin.rest.entity.MUCServiceEntity;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.util.AlreadyExistsException;
-import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +58,7 @@ public class MUCServiceController {
     }
 
     public static void log(String logMessage) {
-        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+        if (RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue()) {
             LOG.info(logMessage);
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
@@ -40,6 +40,11 @@ import java.util.stream.Collectors;
 public class SystemController {
     private static final Logger LOG = LoggerFactory.getLogger(SystemController.class);
 
+    /**
+     * Key prefix used by all system properties owned by this plugin.
+     */
+    private static final String RESTRICTED_PROPERTY_KEY_PREFIX = "plugin.restapi.";
+
     private static SystemController INSTANCE = null;
 
     /**
@@ -84,7 +89,7 @@ public class SystemController {
 
         // Ensure that we're not exposing any 'forbidden' properties.
         final Set<String> forbiddenPropertyKeys = getForbiddenPropertyKeys();
-        compoundProperties.removeIf(systemProperty -> forbiddenPropertyKeys.contains(systemProperty.getKey()));
+        compoundProperties.removeIf(systemProperty -> isForbiddenPropertyKey(systemProperty.getKey(), forbiddenPropertyKeys));
 
         // And sort by key
         compoundProperties.sort(Comparator.comparing(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty::getKey));
@@ -107,7 +112,7 @@ public class SystemController {
 
         final Optional<SystemProperty> systemProperty = SystemProperty.getProperty(propertyKey);
         if (systemProperty.isPresent()) {
-            if (forbiddenPropertyKeys.contains(systemProperty.get().getKey())) {
+            if (isForbiddenPropertyKey(systemProperty.get().getKey(), forbiddenPropertyKeys)) {
                 // Ensure that we're not exposing any 'forbidden' properties.
                 throw new ServiceException("Access to property is forbidden", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
             }
@@ -116,7 +121,7 @@ public class SystemController {
         }
 
         // No system property found. Check JiveGlobals. This cannot distinguish between a property that is not set and a property that is set to null.
-        if (forbiddenPropertyKeys.contains(propertyKey)) {
+        if (isForbiddenPropertyKey(propertyKey, forbiddenPropertyKeys)) {
             // Ensure that we're not exposing any 'forbidden' properties.
             throw new ServiceException("Access to property is forbidden", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
         }
@@ -137,7 +142,7 @@ public class SystemController {
     public void createSystemProperty(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) throws ServiceException
     {
         // Ensure that we're not exposing any 'forbidden' properties.
-        if (getForbiddenPropertyKeys().contains(systemProperty.getKey())) {
+        if (isForbiddenPropertyKey(systemProperty.getKey(), getForbiddenPropertyKeys())) {
             throw new ServiceException("Could not create property", systemProperty.getKey(), ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
         }
         JiveGlobals.setProperty(systemProperty.getKey(), systemProperty.getValue());
@@ -151,7 +156,7 @@ public class SystemController {
      */
     public void deleteSystemProperty(String propertyKey) throws ServiceException {
         // Ensure that we're not exposing any 'forbidden' properties.
-        if (getForbiddenPropertyKeys().contains(propertyKey)) {
+        if (isForbiddenPropertyKey(propertyKey, getForbiddenPropertyKeys())) {
             throw new ServiceException("Could not delete property", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
         }
 
@@ -172,7 +177,7 @@ public class SystemController {
      */
     public void updateSystemProperty(String propertyKey, org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) throws ServiceException {
         // Ensure that we're not exposing any 'forbidden' properties.
-        if (getForbiddenPropertyKeys().contains(propertyKey)) {
+        if (isForbiddenPropertyKey(propertyKey, getForbiddenPropertyKeys())) {
             throw new ServiceException("Could not update property", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
         }
         if(JiveGlobals.getProperty(propertyKey) != null) {
@@ -327,5 +332,22 @@ public class SystemController {
 
             .map(org.jivesoftware.util.SystemProperty::getKey)
             .collect(Collectors.toSet());
+    }
+
+    /**
+     * Determines whether a property key is one that this plugin should not expose or allow modification of.
+     *
+     * Checks the prefix in addition to the given set, as the set can only reflect properties whose owning class has
+     * already been loaded by the JVM (SystemProperty registration is a side effect of static initialization, which
+     * for some of this plugin's properties - e.g. those declared by MUCRoomController - isn't guaranteed to have
+     * happened yet).
+     *
+     * @param propertyKey the property key to check.
+     * @param forbiddenPropertyKeys the result of {@link #getForbiddenPropertyKeys()}, provided by the caller to avoid recomputing it.
+     * @return true if the property key is forbidden, otherwise false.
+     */
+    private static boolean isForbiddenPropertyKey(final String propertyKey, final Set<String> forbiddenPropertyKeys)
+    {
+        return propertyKey != null && (forbiddenPropertyKeys.contains(propertyKey) || propertyKey.startsWith(RESTRICTED_PROPERTY_KEY_PREFIX));
     }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
@@ -81,6 +81,11 @@ public class SystemController {
         final List<org.jivesoftware.openfire.plugin.rest.entity.SystemProperty> compoundProperties = systemProperties.stream().map(p -> new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(p.getKey(), p.getValueAsSaved())).collect(Collectors.toList());
         // Now add any missing JiveGlobals properties
         JiveGlobals.getPropertyNames().stream().filter(key -> !systemPropertyKeys.contains(key)).forEach(key -> compoundProperties.add(new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(key, JiveGlobals.getProperty(key))));
+
+        // Ensure that we're not exposing any 'forbidden' properties.
+        final Set<String> forbiddenPropertyKeys = getForbiddenPropertyKeys();
+        compoundProperties.removeIf(systemProperty -> forbiddenPropertyKeys.contains(systemProperty.getKey()));
+
         // And sort by key
         compoundProperties.sort(Comparator.comparing(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty::getKey));
 
@@ -97,19 +102,30 @@ public class SystemController {
      * @throws ServiceException the service exception
      */
     public org.jivesoftware.openfire.plugin.rest.entity.SystemProperty getSystemProperty(String propertyKey) throws ServiceException {
+        // Ensure that we're not exposing any 'forbidden' properties.
+        final Set<String> forbiddenPropertyKeys = getForbiddenPropertyKeys();
+
         final Optional<SystemProperty> systemProperty = SystemProperty.getProperty(propertyKey);
         if (systemProperty.isPresent()) {
+            if (forbiddenPropertyKeys.contains(systemProperty.get().getKey())) {
+                // Ensure that we're not exposing any 'forbidden' properties.
+                throw new ServiceException("Access to property is forbidden", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
+            }
             // There's guaranteed to be a system property - return a value (even null), no matter what.
             return new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(propertyKey, systemProperty.get().getValueAsSaved());
         }
 
         // No system property found. Check JiveGlobals. This cannot distinguish between a property that is not set and a property that is set to null.
+        if (forbiddenPropertyKeys.contains(propertyKey)) {
+            // Ensure that we're not exposing any 'forbidden' properties.
+            throw new ServiceException("Access to property is forbidden", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
+        }
+
         final String propertyValue = JiveGlobals.getProperty(propertyKey);
         if (propertyValue != null) {
             return new org.jivesoftware.openfire.plugin.rest.entity.SystemProperty(propertyKey, propertyValue);
         } else {
-            throw new ServiceException("Could not find property", propertyKey, ExceptionType.PROPERTY_NOT_FOUND,
-                Response.Status.NOT_FOUND);
+            throw new ServiceException("Could not find property", propertyKey, ExceptionType.PROPERTY_NOT_FOUND, Response.Status.NOT_FOUND);
         }
     }
 
@@ -118,7 +134,12 @@ public class SystemController {
      *
      * @param systemProperty the system property
      */
-    public void createSystemProperty(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) {
+    public void createSystemProperty(org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) throws ServiceException
+    {
+        // Ensure that we're not exposing any 'forbidden' properties.
+        if (getForbiddenPropertyKeys().contains(systemProperty.getKey())) {
+            throw new ServiceException("Could not create property", systemProperty.getKey(), ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
+        }
         JiveGlobals.setProperty(systemProperty.getKey(), systemProperty.getValue());
     }
 
@@ -129,6 +150,11 @@ public class SystemController {
      * @throws ServiceException the service exception
      */
     public void deleteSystemProperty(String propertyKey) throws ServiceException {
+        // Ensure that we're not exposing any 'forbidden' properties.
+        if (getForbiddenPropertyKeys().contains(propertyKey)) {
+            throw new ServiceException("Could not delete property", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
+        }
+
         if(JiveGlobals.getProperty(propertyKey) != null) {
             JiveGlobals.deleteProperty(propertyKey);
         } else {
@@ -145,6 +171,10 @@ public class SystemController {
      * @throws ServiceException the service exception
      */
     public void updateSystemProperty(String propertyKey, org.jivesoftware.openfire.plugin.rest.entity.SystemProperty systemProperty) throws ServiceException {
+        // Ensure that we're not exposing any 'forbidden' properties.
+        if (getForbiddenPropertyKeys().contains(propertyKey)) {
+            throw new ServiceException("Could not update property", propertyKey, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN);
+        }
         if(JiveGlobals.getProperty(propertyKey) != null) {
             if(systemProperty.getKey().equals(propertyKey)) {
                 JiveGlobals.setProperty(propertyKey, systemProperty.getValue());
@@ -280,5 +310,22 @@ public class SystemController {
         }
 
         return true;
+    }
+
+    /**
+     * Returns a set of system property keys that are not allowed to be modified via the REST API.
+     *
+     * @return a set of system property keys (never null, possibly empty).
+     */
+    public static Set<String> getForbiddenPropertyKeys()
+    {
+        final String pluginName = RESTServicePlugin.ENABLED.getPlugin();
+        return org.jivesoftware.util.SystemProperty.getProperties().stream()
+
+            // Do not allow modifications of the configuration of this plugin itself. See https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+            .filter(p -> pluginName.equals(p.getPlugin())) // This works only because all properties used by the plugin are SystemProperty instances (as opposed to using JiveGlobals directly).
+
+            .map(org.jivesoftware.util.SystemProperty::getKey)
+            .collect(Collectors.toSet());
     }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/SystemController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (c) 2022-2026 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class SystemController {
     }
 
     public static void log(String logMessage) {
-        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+        if (RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue()) {
             LOG.info(logMessage);
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceController.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/controller/UserServiceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (c) 2022-2026 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.vcard.VCardManager;
-import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -109,7 +108,7 @@ public class UserServiceController {
     }
 
     public static void log(String logMessage) {
-        if (JiveGlobals.getBooleanProperty(RESTServicePlugin.SERVICE_LOGGING_ENABLED, false)) {
+        if (RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue()) {
             LOG.info(logMessage);
         }
     }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/CustomOpenApiResource.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/CustomOpenApiResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class CustomOpenApiResource extends BaseOpenApiResource {
         openAPI.components(new Components());
 
         final String key;
-        if (plugin == null || !"basic".equals(plugin.getHttpAuth())) {
+        if (plugin == null || !RESTServicePlugin.AuthType.basic.equals(RESTServicePlugin.AUTH_TYPE.getValue())) {
             key = "Secret key auth";
             final SecurityScheme apiKeyScheme = new SecurityScheme();
             apiKeyScheme.setDescription("Authenticate using the Secret Key as configured in the Openfire admin console.");

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,7 @@
 package org.jivesoftware.openfire.plugin.rest.service;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.jivesoftware.openfire.plugin.rest.AuthFilter;
-import org.jivesoftware.openfire.plugin.rest.CORSFilter;
-import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
-import org.jivesoftware.openfire.plugin.rest.StatisticsFilter;
+import org.jivesoftware.openfire.plugin.rest.*;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 
 import javax.servlet.ServletConfig;
@@ -32,9 +29,6 @@ import java.util.logging.Logger;
  * The Class JerseyWrapper.
  */
 public class JerseyWrapper extends ResourceConfig {
-
-    /** The Constant REST_AUTH_TYPE */
-    private static final String REST_AUTH_TYPE  = "plugin.restapi.httpAuth";
 
     /** The Constant SERVLET_URL. */
     public static final String SERVLET_URL = "restapi/*";
@@ -68,11 +62,11 @@ public class JerseyWrapper extends ResourceConfig {
 
         // Check if custom AuthFilter is available
         String customAuthFilterClassName = RESTServicePlugin.CUSTOM_AUTH_FILTER.getValue();
-        String restAuthType = JiveGlobals.getProperty(REST_AUTH_TYPE);
+        RESTServicePlugin.AuthType restAuthType = RESTServicePlugin.AUTH_TYPE.getValue();
         Class<?> pickedAuthFilter = AuthFilter.class;
         
         try {
-            if(customAuthFilterClassName != null && "custom".equals(restAuthType)) {
+            if(customAuthFilterClassName != null && RESTServicePlugin.AuthType.custom.equals(restAuthType)) {
                 pickedAuthFilter = Class.forName(customAuthFilterClassName, false, JerseyWrapper.class.getClassLoader());
                 loadingStatusMessage = null;
             }

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/JerseyWrapper.java
@@ -22,7 +22,6 @@ import org.jivesoftware.openfire.plugin.rest.CORSFilter;
 import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
 import org.jivesoftware.openfire.plugin.rest.StatisticsFilter;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
-import org.jivesoftware.util.JiveGlobals;
 
 import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
@@ -34,9 +33,6 @@ import java.util.logging.Logger;
  */
 public class JerseyWrapper extends ResourceConfig {
 
-    /** The Constant CUSTOM_AUTH_PROPERTY_NAME */
-    private static final String CUSTOM_AUTH_PROPERTY_NAME = "plugin.restapi.customAuthFilter";
-    
     /** The Constant REST_AUTH_TYPE */
     private static final String REST_AUTH_TYPE  = "plugin.restapi.httpAuth";
 
@@ -69,9 +65,9 @@ public class JerseyWrapper extends ResourceConfig {
     }
     
     public String loadAuthenticationFilter() {
-            
+
         // Check if custom AuthFilter is available
-        String customAuthFilterClassName = JiveGlobals.getProperty(CUSTOM_AUTH_PROPERTY_NAME);
+        String customAuthFilterClassName = RESTServicePlugin.CUSTOM_AUTH_FILTER.getValue();
         String restAuthType = JiveGlobals.getProperty(REST_AUTH_TYPE);
         Class<?> pickedAuthFilter = AuthFilter.class;
         

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
@@ -55,6 +55,7 @@ public class SystemService {
         description = "Get a specific Openfire system property.",
         responses = {
             @ApiResponse(responseCode = "200", description = "The requested system property.", content = @Content(schema = @Schema(implementation = SystemProperty.class))),
+            @ApiResponse(responseCode = "403", description = "Reading this system property is prohibited."),
             @ApiResponse(responseCode = "404", description = "The system property could not be found.")
         })
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/SystemService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (c) 2022-2026 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ public class SystemService {
         description = "Create a new Openfire system property. Will overwrite a pre-existing system property that uses the same name.",
         responses = {
             @ApiResponse(responseCode = "201", description = "The system property is created."),
+            @ApiResponse(responseCode = "403", description = "Prohibited to create this system property."),
         })
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public Response createSystemProperty(
@@ -88,6 +89,7 @@ public class SystemService {
         responses = {
             @ApiResponse(responseCode = "200", description = "The system property is updated."),
             @ApiResponse(responseCode = "400", description = "The provided system property does not match the name in the URL."),
+            @ApiResponse(responseCode = "403", description = "Prohibited to update this system property."),
             @ApiResponse(responseCode = "404", description = "The system property could not be found.")
         })
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
@@ -106,6 +108,7 @@ public class SystemService {
         description = "Removes an existing Openfire system property.",
         responses = {
             @ApiResponse(responseCode = "200", description = "The system property is deleted."),
+            @ApiResponse(responseCode = "403", description = "Prohibited to delete this system property."),
             @ApiResponse(responseCode = "404", description = "The system property could not be found.")
         })
     public Response deleteSystemProperty(

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/UserServiceLegacy.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/UserServiceLegacy.java
@@ -112,7 +112,7 @@ public class UserServiceLegacy {
         }
 
         // Check this request is authorised
-        if (secret == null || !secret.equals(plugin.getSecret())) {
+        if (secret == null || secret.isEmpty() || !secret.equals(RESTServicePlugin.SECRET.getValue())) {
             LOG.warn("An unauthorised user service request was received: " + request.getQueryString());
             replyError("RequestNotAuthorised", response, out);
             return Response.status(200).build();

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/UserServiceLegacy.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/UserServiceLegacy.java
@@ -73,7 +73,7 @@ public class UserServiceLegacy {
         // Printwriter for writing out responses to browser
         PrintWriter out = response.getWriter();
 
-        if (!plugin.getAllowedIPs().isEmpty()) {
+        if (!RESTServicePlugin.ALLOWED_IPS.getValue().isEmpty()) {
             // Get client's IP address
             String ipAddress = request.getHeader("x-forwarded-for");
             if (ipAddress == null) {
@@ -85,7 +85,7 @@ public class UserServiceLegacy {
                     }
                 }
             }
-            if (!plugin.getAllowedIPs().contains(ipAddress)) {
+            if (!RESTServicePlugin.ALLOWED_IPS.getValue().contains(ipAddress)) {
                 LOG.warn("User service rejected service to IP address: " + ipAddress);
                 replyError("RequestNotAuthorised", response, out);
                 return Response.status(200).build();

--- a/src/java/org/jivesoftware/openfire/plugin/rest/service/UserServiceLegacy.java
+++ b/src/java/org/jivesoftware/openfire/plugin/rest/service/UserServiceLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class UserServiceLegacy {
         // type = type == null ? "image" : type;
 
         // Check that our plugin is enabled.
-        if (!plugin.isEnabled()) {
+        if (!RESTServicePlugin.ENABLED.getValue()) {
             LOG.warn("User service plugin is disabled: " + request.getQueryString());
             replyError("UserServiceDisabled", response, out);
             return Response.status(200).build();

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/controller/SystemControllerTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/controller/SystemControllerTest.java
@@ -15,11 +15,16 @@
  */
 package org.jivesoftware.openfire.plugin.rest.controller;
 
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.SystemProperty;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
@@ -30,10 +35,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Unit tests for {@link SystemController}, in particular for the retrieval of an individual system property.
@@ -46,6 +53,34 @@ import static org.mockito.Mockito.when;
 public class SystemControllerTest {
 
     private SystemController systemController;
+
+    /**
+     * Constructs a mock of the XMPPServer implementation, providing enough metadata to allow
+     * {@link RESTServicePlugin}'s static {@link SystemProperty} fields to be built.
+     *
+     * @return A mock of a XMPPServer
+     */
+    private static XMPPServer constructMockXmppServer() {
+        final PluginManager pluginManager = mock(PluginManager.class, withSettings().lenient());
+        final XMPPServer xmppServer = mock(XMPPServer.class, withSettings().lenient());
+        doAnswer(invocationOnMock -> pluginManager).when(xmppServer).getPluginManager();
+        return xmppServer;
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        // SystemController#getForbiddenPropertyKeys() (invoked by getSystemProperty()) references
+        // RESTServicePlugin.ENABLED, triggering the one-time, JVM-wide static initialization of RESTServicePlugin.
+        // That initialization builds SystemProperty instances, which require a running server. Install a mock here
+        // so that this test class does not depend on some other, unrelated test class having already done so, in
+        // whatever arbitrary order Surefire happens to run test classes in.
+        XMPPServer.setInstance(constructMockXmppServer());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        XMPPServer.setInstance(null);
+    }
 
     @Before
     public void setUp() {

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/controller/SystemControllerTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/controller/SystemControllerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 
 import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -75,6 +76,11 @@ public class SystemControllerTest {
         // so that this test class does not depend on some other, unrelated test class having already done so, in
         // whatever arbitrary order Surefire happens to run test classes in.
         XMPPServer.setInstance(constructMockXmppServer());
+
+        // Force RESTServicePlugin to load now, while the mock above is in place and no test-method-scoped
+        // MockedStatic block is active, rather than relying on it being lazily loaded as a side effect of
+        // whichever test happens to run first.
+        RESTServicePlugin.ENABLED.getPlugin();
     }
 
     @AfterClass
@@ -214,6 +220,30 @@ public class SystemControllerTest {
             systemController.getSystemProperty(key);
 
             jiveGlobalsMock.verify(() -> JiveGlobals.getProperty(eq(key)), never());
+        }
+    }
+
+    /**
+     * A property that belongs to this plugin (identified by its {@code plugin.restapi.} key prefix) must remain
+     * forbidden even when it is not (yet) present in {@link SystemProperty#getProperties()} - which can happen when
+     * the class that declares it (e.g. {@code MUCRoomController}) has not yet been loaded by the JVM, as
+     * SystemProperty registration happens as a side effect of static initialization.
+     */
+    @Test
+    public void testGetSystemPropertyWithRestApiPrefixIsForbiddenEvenWhenNotYetRegistered() {
+        final String key = "plugin.restapi.muc.room-mutex.enabled";
+
+        try (final MockedStatic<SystemProperty> systemPropertyMock = mockStatic(SystemProperty.class);
+             final MockedStatic<JiveGlobals> jiveGlobalsMock = mockStatic(JiveGlobals.class)) {
+            // Simulate the property's owning class not having loaded yet: it's absent from both lookups.
+            systemPropertyMock.when(() -> SystemProperty.getProperty(eq(key))).thenReturn(Optional.empty());
+            systemPropertyMock.when(SystemProperty::getProperties).thenReturn(Collections.emptyList());
+            jiveGlobalsMock.when(() -> JiveGlobals.getProperty(eq(key))).thenReturn("false");
+
+            final ServiceException exception = assertThrows(ServiceException.class, () -> systemController.getSystemProperty(key));
+
+            assertEquals(ExceptionType.NOT_ALLOWED, exception.getException());
+            assertEquals(Response.Status.FORBIDDEN, exception.getStatus());
         }
     }
 }

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/ClusteringServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/ClusteringServiceBackwardCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.roster.RosterItem;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -97,6 +98,11 @@ public class ClusteringServiceBackwardCompatibilityTest extends JerseyTest {
     public static void setUpClass() throws ServiceException {
         // Override the service controller with a mock controller.
         ClusteringController.setInstance(constructMockController());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        ClusteringController.setInstance(null);
     }
 
     @Before

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomMembersServiceBackwardCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.jivesoftware.openfire.plugin.rest.CustomJacksonMapperProvider;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -83,6 +84,12 @@ public class MUCRoomMembersServiceBackwardCompatibilityTest extends JerseyTest {
 
         // Override the service controller with a mock controller.
         MUCRoomController.setInstance(constructMockController());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        XMPPServer.setInstance(null);
+        MUCRoomController.setInstance(null);
     }
 
     @Override

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomServiceBackwardCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntity;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -150,6 +151,12 @@ public class MUCRoomServiceBackwardCompatibilityTest extends JerseyTest {
 
         // Override the service controller with a mock controller.
         MUCRoomController.setInstance(constructMockController());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        XMPPServer.setInstance(null);
+        MUCRoomController.setInstance(null);
     }
 
     @Before

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/SystemServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/SystemServiceBackwardCompatibilityTest.java
@@ -25,6 +25,7 @@ import org.jivesoftware.openfire.plugin.rest.entity.SystemProperty;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -98,6 +99,11 @@ public class SystemServiceBackwardCompatibilityTest extends JerseyTest {
     public static void setUpClass() throws ServiceException {
         // Override the service controller with a mock controller.
         SystemController.setInstance(constructMockController());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        SystemController.setInstance(null);
     }
 
     @Override

--- a/src/test/java/org/jivesoftware/openfire/plugin/rest/service/UserRosterServiceBackwardCompatibilityTest.java
+++ b/src/test/java/org/jivesoftware/openfire/plugin/rest/service/UserRosterServiceBackwardCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.plugin.rest.entity.RosterItemEntity;
 import org.jivesoftware.openfire.plugin.rest.exceptions.RESTExceptionMapper;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.roster.RosterItem;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -75,6 +76,11 @@ public class UserRosterServiceBackwardCompatibilityTest extends JerseyTest {
     public static void setUpClass() throws ServiceException {
         // Override the service controller with a mock controller.
         UserServiceController.setInstance(constructMockController());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        UserServiceController.setInstance(null);
     }
 
     @Override

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -68,7 +68,7 @@
             
             boolean is2Reload = "custom".equals(httpAuth) || "custom".equals(plugin.getHttpAuth());
             plugin.setEnabled(enabled);
-            plugin.setSecret(secret);
+            RESTServicePlugin.SECRET.setValue(secret == null || secret.isEmpty() ? StringUtils.randomString(16) : secret);
             plugin.setHttpAuth(httpAuth);
             plugin.setAllowedIPs(StringUtils.stringToCollection(allowedIPs));
             plugin.setCustomAuthFiIterClassName(customAuthFilterClassName);
@@ -88,7 +88,7 @@
         }
     }
 
-    secret = plugin.getSecret();
+    secret = RESTServicePlugin.SECRET.getValue();
     enabled = plugin.isEnabled();
     httpAuth = plugin.getHttpAuth();
     allowedIPs = StringUtils.collectionToString(plugin.getAllowedIPs());

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -77,7 +77,7 @@
             RESTServicePlugin.ENABLED.setValue(enabled);
             RESTServicePlugin.SECRET.setValue(secret == null || secret.isEmpty() ? StringUtils.randomString(16) : secret);
             RESTServicePlugin.AUTH_TYPE.setValue(authType);
-            plugin.setAllowedIPs(StringUtils.stringToCollection(allowedIPs));
+            RESTServicePlugin.ALLOWED_IPS.setValue(new HashSet<>(StringUtils.stringToCollection(allowedIPs)));
             RESTServicePlugin.CUSTOM_AUTH_FILTER.setValue(customAuthFilterClassName);
             RESTServicePlugin.SERVICE_LOGGING_ENABLED.setValue(loggingEnabled);
 
@@ -98,7 +98,7 @@
     secret = RESTServicePlugin.SECRET.getValue();
     enabled = RESTServicePlugin.ENABLED.getValue();
     authType = RESTServicePlugin.AUTH_TYPE.getValue();
-    allowedIPs = StringUtils.collectionToString(plugin.getAllowedIPs());
+    allowedIPs = StringUtils.collectionToString(RESTServicePlugin.ALLOWED_IPS.getValue());
     customAuthFilterClassName = RESTServicePlugin.CUSTOM_AUTH_FILTER.getValue();
     loggingEnabled = RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue();
 %>

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -72,7 +72,7 @@
             plugin.setHttpAuth(httpAuth);
             plugin.setAllowedIPs(StringUtils.stringToCollection(allowedIPs));
             plugin.setCustomAuthFiIterClassName(customAuthFilterClassName);
-            plugin.setServiceLoggingEnabled(loggingEnabled);
+            RESTServicePlugin.SERVICE_LOGGING_ENABLED.setValue(loggingEnabled);
 
             if(is2Reload) {
                 String pluginName  = PluginMetadataHelper.getName(plugin);
@@ -93,7 +93,7 @@
     httpAuth = plugin.getHttpAuth();
     allowedIPs = StringUtils.collectionToString(plugin.getAllowedIPs());
     customAuthFilterClassName = plugin.getCustomAuthFilterClassName();
-    loggingEnabled = plugin.isServiceLoggingEnabled();
+    loggingEnabled = RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue();
 %>
 
 <html>

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -1,6 +1,6 @@
 <%--
 /*
- * Copyright (c) 2022.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
     boolean success = request.getParameter("success") != null;
     String secret = ParamUtils.getParameter(request, "secret");
     boolean enabled = ParamUtils.getBooleanParameter(request, "enabled");
-    String httpAuth = ParamUtils.getParameter(request, "authtype");
+    String authTypeString = ParamUtils.getParameter(request, "authtype");
     String allowedIPs = ParamUtils.getParameter(request, "allowedIPs");
     String customAuthFilterClassName = ParamUtils.getParameter(request, "customAuthFilterClassName");
     boolean loggingEnabled = ParamUtils.getBooleanParameter(request, "loggingEnabled");
@@ -54,21 +54,29 @@
             .getPluginByName("REST API").orElse(null);
 
     // Handle a save
-    Map errors = new HashMap();
+    Map<String, String> errors = new HashMap<>();
+
+    RESTServicePlugin.AuthType authType = null;
     if (save) {
-        if("custom".equals(httpAuth)) {
+        try {
+            authType = RESTServicePlugin.AuthType.valueOf(authTypeString);
+        } catch (Exception e) {
+            errors.put("authtype", "invalid value");
+        }
+
+        if (RESTServicePlugin.AuthType.custom.equals(authType)) {
             loadingStatus = plugin.loadAuthenticationFilter(customAuthFilterClassName);
         }
         if (loadingStatus != null) {
             errors.put("loadingStatus", loadingStatus);
         }
-        
-        if (errors.size() == 0) {
-            
-            boolean is2Reload = "custom".equals(httpAuth) || "custom".equals(plugin.getHttpAuth());
+
+        if (errors.isEmpty())
+        {
+            boolean is2Reload = RESTServicePlugin.AuthType.custom.equals(authType) || RESTServicePlugin.AuthType.custom.equals(RESTServicePlugin.AUTH_TYPE.getValue());
             RESTServicePlugin.ENABLED.setValue(enabled);
             RESTServicePlugin.SECRET.setValue(secret == null || secret.isEmpty() ? StringUtils.randomString(16) : secret);
-            plugin.setHttpAuth(httpAuth);
+            RESTServicePlugin.AUTH_TYPE.setValue(authType);
             plugin.setAllowedIPs(StringUtils.stringToCollection(allowedIPs));
             RESTServicePlugin.CUSTOM_AUTH_FILTER.setValue(customAuthFilterClassName);
             RESTServicePlugin.SERVICE_LOGGING_ENABLED.setValue(loggingEnabled);
@@ -89,7 +97,7 @@
 
     secret = RESTServicePlugin.SECRET.getValue();
     enabled = RESTServicePlugin.ENABLED.getValue();
-    httpAuth = plugin.getHttpAuth();
+    authType = RESTServicePlugin.AUTH_TYPE.getValue();
     allowedIPs = StringUtils.collectionToString(plugin.getAllowedIPs());
     customAuthFilterClassName = RESTServicePlugin.CUSTOM_AUTH_FILTER.getValue();
     loggingEnabled = RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue();
@@ -144,6 +152,27 @@
     <%
         }
     %>
+    <%
+        if (errors.get("authtype") != null) {
+    %>
+    <div class="jive-error">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tbody>
+            <tr>
+                <td class="jive-icon"><img src="images/error-16x16.gif"
+                                           width="16" height="16" border="0"></td>
+                <td class="jive-icon-label">Unrecognized authentication type.
+
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <br>
+    <%
+        }
+    %>
+
     <form action="rest-api.jsp?save" method="post">
 
         <fieldset>
@@ -170,12 +199,12 @@
                     <br>
 
                     <input type="radio" name="authtype" value="basic"
-                        id="http_basic_auth" <%=("basic".equals(httpAuth) ? "checked" : "")%>>
+                        id="http_basic_auth" <%=(RESTServicePlugin.AuthType.basic.equals(authType) ? "checked" : "")%>>
                     <label for="http_basic_auth">HTTP basic auth - REST API
                         authentication with Openfire admin account.</label>
                     <br>
                     <input type="radio" name="authtype" value="secret"
-                        id="secretKeyAuth" <%=("secret".equals(httpAuth) ? "checked" : "")%>>
+                        id="secretKeyAuth" <%=(RESTServicePlugin.AuthType.secret.equals(authType) ? "checked" : "")%>>
                     <label for="secretKeyAuth">Secret key auth - REST API
                         authentication over specified secret key.</label>
                     <br>
@@ -185,7 +214,7 @@
                         id="text_secret">
                     <br>
                     <input type="radio" name="authtype" value="custom"
-                        id="customFilterAuth" <%=("custom".equals(httpAuth) ? "checked" : "")%>>
+                        id="customFilterAuth" <%=(RESTServicePlugin.AuthType.custom.equals(authType) ? "checked" : "")%>>
                     <label for="secretKeyAuth">Custom authentication filter classname - REST API
                         authentication delegates to a custom filter implemented in some other plugin.
                     </label>

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -21,7 +21,6 @@
     import="java.util.*,
                 org.jivesoftware.openfire.XMPPServer,
                 org.jivesoftware.util.*,org.jivesoftware.openfire.plugin.rest.RESTServicePlugin,
-                org.jivesoftware.openfire.container.Plugin,
                 org.jivesoftware.openfire.container.PluginManager"
     errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.container.PluginMetadataHelper" %>
@@ -71,7 +70,7 @@
             RESTServicePlugin.SECRET.setValue(secret == null || secret.isEmpty() ? StringUtils.randomString(16) : secret);
             plugin.setHttpAuth(httpAuth);
             plugin.setAllowedIPs(StringUtils.stringToCollection(allowedIPs));
-            plugin.setCustomAuthFiIterClassName(customAuthFilterClassName);
+            RESTServicePlugin.CUSTOM_AUTH_FILTER.setValue(customAuthFilterClassName);
             RESTServicePlugin.SERVICE_LOGGING_ENABLED.setValue(loggingEnabled);
 
             if(is2Reload) {
@@ -92,7 +91,7 @@
     enabled = plugin.isEnabled();
     httpAuth = plugin.getHttpAuth();
     allowedIPs = StringUtils.collectionToString(plugin.getAllowedIPs());
-    customAuthFilterClassName = plugin.getCustomAuthFilterClassName();
+    customAuthFilterClassName = RESTServicePlugin.CUSTOM_AUTH_FILTER.getValue();
     loggingEnabled = RESTServicePlugin.SERVICE_LOGGING_ENABLED.getValue();
 %>
 

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -215,7 +215,7 @@
                     <br>
                     <input type="radio" name="authtype" value="custom"
                         id="customFilterAuth" <%=(RESTServicePlugin.AuthType.custom.equals(authType) ? "checked" : "")%>>
-                    <label for="secretKeyAuth">Custom authentication filter classname - REST API
+                    <label for="customFilterAuth">Custom authentication filter classname - REST API
                         authentication delegates to a custom filter implemented in some other plugin.
                     </label>
                     <div style="margin-left: 20px; margin-top: 5px;"><strong>Note: changing back and forth from custom authentication filter forces the REST API plugin reloading</strong></div>

--- a/src/web/rest-api.jsp
+++ b/src/web/rest-api.jsp
@@ -66,7 +66,7 @@
         if (errors.size() == 0) {
             
             boolean is2Reload = "custom".equals(httpAuth) || "custom".equals(plugin.getHttpAuth());
-            plugin.setEnabled(enabled);
+            RESTServicePlugin.ENABLED.setValue(enabled);
             RESTServicePlugin.SECRET.setValue(secret == null || secret.isEmpty() ? StringUtils.randomString(16) : secret);
             plugin.setHttpAuth(httpAuth);
             plugin.setAllowedIPs(StringUtils.stringToCollection(allowedIPs));
@@ -88,7 +88,7 @@
     }
 
     secret = RESTServicePlugin.SECRET.getValue();
-    enabled = plugin.isEnabled();
+    enabled = RESTServicePlugin.ENABLED.getValue();
     httpAuth = plugin.getHttpAuth();
     allowedIPs = StringUtils.collectionToString(plugin.getAllowedIPs());
     customAuthFilterClassName = RESTServicePlugin.CUSTOM_AUTH_FILTER.getValue();

--- a/test/system.hurl
+++ b/test/system.hurl
@@ -103,3 +103,146 @@ HTTP 400
 DELETE http://localhost:9090/plugins/restapi/v1/system/properties/test.key
 Authorization: {{authkey}}
 HTTP 200
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+GET http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.enabled
+Authorization: {{authkey}}
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+PUT http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.enabled
+Authorization: {{authkey}}
+Content-Type: application/xml
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<property key="plugin.restapi.enabled" value="true" />
+```
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+DELETE http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.enabled
+Authorization: {{authkey}}
+HTTP 403
+
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+GET http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.httpAuth
+Authorization: {{authkey}}
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+PUT http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.httpAuth
+Authorization: {{authkey}}
+Content-Type: application/xml
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<property key="plugin.restapi.httpAuth" value="custom" />
+```
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+DELETE http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.httpAuth
+Authorization: {{authkey}}
+HTTP 403
+
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+GET http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.customAuthFilter
+Authorization: {{authkey}}
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+PUT http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.customAuthFilter
+Authorization: {{authkey}}
+Content-Type: application/xml
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<property key="plugin.restapi.customAuthFilter" value="test.class" />
+```
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+DELETE http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.customAuthFilter
+Authorization: {{authkey}}
+HTTP 403
+
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+GET http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.secret
+Authorization: {{authkey}}
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+PUT http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.secret
+Authorization: {{authkey}}
+Content-Type: application/xml
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<property key="plugin.restapi.secret" value="test" />
+```
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+DELETE http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.secret
+Authorization: {{authkey}}
+HTTP 403
+
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+GET http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.serviceLoggingEnabled
+Authorization: {{authkey}}
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+PUT http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.serviceLoggingEnabled
+Authorization: {{authkey}}
+Content-Type: application/xml
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<property key="plugin.restapi.serviceLoggingEnabled" value="true" />
+```
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+DELETE http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.serviceLoggingEnabled
+Authorization: {{authkey}}
+HTTP 403
+
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+GET http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.allowedIPs
+Authorization: {{authkey}}
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+PUT http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.allowedIPs
+Authorization: {{authkey}}
+Content-Type: application/xml
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<property key="plugin.restapi.allowedIPs" value="true" />
+```
+HTTP 403
+
+# https://github.com/igniterealtime/openfire-restAPI-plugin/issues/244
+# The REST API plugin should not allow users to access properties used to control the plugin's functionality.
+DELETE http://localhost:9090/plugins/restapi/v1/system/properties/plugin.restapi.allowedIPs
+Authorization: {{authkey}}
+HTTP 403


### PR DESCRIPTION
The REST API plugin's system properties endpoints (GET/POST/PUT/DELETE /plugins/restapi/v1/system/properties) allowed
reading and writing any Openfire system property, including the properties that control the REST API plugin's own behavior This allowed a caller with REST API access to durably reconfigure the plugin's own authentication, amongst others

This PR:
- Migrates the plugin's remaining raw JiveGlobals-backed settings to Openfire's typed SystemProperty API with plugin="REST API"
- Add SystemController.getForbiddenPropertyKeys(), which derives the set of properties owned by this plugin from SystemPropert metadata rather than an explicit key list, so any current or future `plugin.restapi.*` property is covered automatically.
- Enforce this block consistently across all  property operations, returning 403 rather than exposing or accepting changes to these keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - REST API configuration properties are protected from system-property endpoint access; prohibited requests return HTTP 403.
  - Authentication settings are validated, and empty secrets are rejected.

- **Configuration**
  - REST API settings are managed dynamically with clearer English and Dutch descriptions.
  - Authentication options include basic, secret, and custom modes.

- **Compatibility**
  - Plugin support is restricted to server versions before 5.2.0.

- **Tests**
  - Added coverage for blocked read, update, and delete requests involving protected configuration properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->