### PR TITLE
fixes #251: Override & bump testing dependencies to enable some JUnit 5 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <properties>
         <jersey.version>2.45</jersey.version>
         <swagger.version>2.2.55</swagger.version>
+        <junit.jupiter.version>6.1.3</junit.jupiter.version>
     </properties>
 
     <developers>
@@ -40,6 +41,10 @@
             <plugin>
                 <groupId>org.eclipse.jetty.ee8</groupId>
                 <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.6.0</version> <!-- Override inherited 2.17 to enable JUnit 5 tests -->
             </plugin>
         </plugins>
     </build>
@@ -126,6 +131,19 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Required by plain-JUnit-4 *BackwardCompatibilityTest classes -->
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION

- Bump the Openfire-inherited `maven-surefire-plugin` to enable JUnit 5 tests.
- Override and bump transitive Jupiter for more modern JUnit 5 dependencies
- Include JUnit Vintage to preserve JUnit 4 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added support for running JUnit 5 tests.
  * Preserved compatibility with existing JUnit 4 tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->